### PR TITLE
DCCODE-105 kicked back

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 District of Columbia law (statutes and code) in XML format.
 
-_master_: [![Build status](https://ci.appveyor.com/api/projects/status/i8nm5au85u2wufld/branch/master?svg=true)](https://ci.appveyor.com/project/oll-bot/dc-law-xml/branch/master)
+_master_: [![Build status](https://ci.appveyor.com/api/projects/status/l9vfnxerqha83s03/branch/master?svg=true)](https://ci.appveyor.com/project/oll-bot/dc-law-xml/branch/master)
 
-_development_: [![Build status](https://ci.appveyor.com/api/projects/status/i8nm5au85u2wufld/branch/development?svg=true)](https://ci.appveyor.com/project/oll-bot/dc-law-xml/branch/development)
+_development_: [![Build status](https://ci.appveyor.com/api/projects/status/l9vfnxerqha83s03/branch/development?svg=true)](https://ci.appveyor.com/project/oll-bot/dc-law-xml/branch/development)
 
 
 # Branches


### PR DESCRIPTION
It looks like the problem is that the badges were pointing to the AppVeyor _openlawlibrary/dc-law-xml_ project (which we deleted) instead of to the AppVeyor _dccouncil/dc-law-xml_ project (which we want to use going forward).