### PR TITLE
 Split codification process from HTMLification process DCCODE-169

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,11 @@ before_build:
   # run the tests here (instead of AppVeyor's "test" phase, which runs *after* the "build" phase)
   - xcore\console ..\dc-law-xml
   # now install the codified files and tools prior to codifying
-  - git clone --depth 1 --branch %appveyor_repo_branch% git@github.com:openlawlibrary/dc-law-xml-codified.git ..\dc-law-xml-codified
+  - git clone --depth 1 git@github.com:openlawlibrary/dc-law-xml-codified.git ..\dc-law-xml-codified
+  # use or create a branch in dc-law-xml-codified with the same name
+  - git -C ..\dc-law-xml-codified fetch origin %appveyor_repo_branch% &&
+    git -C ..\dc-law-xml-codified checkout %appveyor_repo_branch% ||
+    git -C ..\dc-law-xml-codified checkout -b %appveyor_repo_branch%
   - git clone --depth 1 git@github.com:openlawlibrary/dc-law-tools.git ..\dc-law-tools
   # dc-law-tools has some requirements that must be installed before building
   - "%PYTHON%\\python.exe -m pip install wheel"
@@ -49,4 +53,4 @@ deploy_script:
   - cd ..\dc-law-xml-codified
   - git add -A
   - git diff --cached --quiet || git commit -m "deploy codified XML from dc-law-xml build %appveyor_build_version%"
-  - git push
+  - git push origin %appveyor_repo_branch%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+clone_folder: c:\projects\dc-law-xml
+
 environment:
   matrix:
     - PYTHON: "C:\\Python35"
@@ -30,10 +32,9 @@ before_build:
   - 7z e xcore.zip -oxcore
   # run the tests here (instead of AppVeyor's "test" phase, which runs *after* the "build" phase)
   - xcore\console ..\dc-law-xml
-  # now install the HTML files and tools prior to building the HTML
-  - git clone --depth 1 git@github.com:openlawlibrary/dc-law-static.git ..\dc-law-static
-  - git clone --depth 1 --branch %appveyor_repo_branch% git@github.com:dccouncil/dc-law-html.git ..\dc-law-html
-  - git clone --depth 1 git@github.com:openlawlibrary/dc-law-tools.git ..\dc-law-tools
+  # now install the codified files and tools prior to codifying
+  - git clone --depth 1 --branch %appveyor_repo_branch% git@github.com:openlawlibrary/dc-law-xml-codified.git ..\dc-law-xml-codified
+  - git clone --depth 1 --branch DCCODE-169 git@github.com:openlawlibrary/dc-law-tools.git ..\dc-law-tools
   # dc-law-tools has some requirements that must be installed before building
   - "%PYTHON%\\python.exe -m pip install wheel"
   - "%PYTHON%\\python.exe -m pip install    ..\\dc-law-tools\\requirements\\lxml-3.6.4-cp35-cp35m-win32.whl"
@@ -41,14 +42,13 @@ before_build:
 
 build_script:
   - cd ..\dc-law-tools
-  - "%PYTHON%\\python.exe build html all"
+  - "%PYTHON%\\python.exe build codify"
 
 test_script:
   - echo Skipping doomed test discovery to save time
 
 deploy_script:
-  - cd ..\dc-law-html
-  - echo "%APPVEYOR_BUILD_VERSION%" > version.html
+  - cd ..\dc-law-xml-codified
   - git add -A
-  - git diff --cached --quiet || git commit -m "deploy HTML from AppVeyor build %appveyor_build_version%"
-  - git push origin %appveyor_repo_branch%
+  - git diff --cached --quiet || git commit -m "deploy codified XML from dc-law-xml build %appveyor_build_version%"
+  - git push

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,3 @@
-clone_folder: c:\projects\dc-law-xml
-
 environment:
   matrix:
     - PYTHON: "C:\\Python35"
@@ -34,7 +32,7 @@ before_build:
   - xcore\console ..\dc-law-xml
   # now install the codified files and tools prior to codifying
   - git clone --depth 1 --branch %appveyor_repo_branch% git@github.com:openlawlibrary/dc-law-xml-codified.git ..\dc-law-xml-codified
-  - git clone --depth 1 --branch DCCODE-169 git@github.com:openlawlibrary/dc-law-tools.git ..\dc-law-tools
+  - git clone --depth 1 git@github.com:openlawlibrary/dc-law-tools.git ..\dc-law-tools
   # dc-law-tools has some requirements that must be installed before building
   - "%PYTHON%\\python.exe -m pip install wheel"
   - "%PYTHON%\\python.exe -m pip install    ..\\dc-law-tools\\requirements\\lxml-3.6.4-cp35-cp35m-win32.whl"


### PR DESCRIPTION
This PR modifies _appveyor.yml_ to run `build codify` and commit the results to the _dc-law-xml-codified_ repo (instead of running `build html` and committing into _dc-law-html_).