### PR TITLE
allow creating of new branches to succeed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ before_build:
   - xcore-win\console . schemas\dc-library.xsd
   # now install the tools and codified files prior to codifying
   - git clone --depth 1 git@github.com:openlawlibrary/dc-law-tools.git ..\dc-law-tools
-  - git clone --depth 1 git@github.com:dccouncil/dc-law-xml-codified.git ..\dc-law-xml-codified
+  - git clone --depth --no-single-branch 1 git@github.com:dccouncil/dc-law-xml-codified.git ..\dc-law-xml-codified
   # use or create a branch in dc-law-xml-codified with the same name
   - git -C ..\dc-law-xml-codified fetch origin %appveyor_repo_branch% &&
     git -C ..\dc-law-xml-codified checkout %appveyor_repo_branch% ||


### PR DESCRIPTION
We're using `git clone --depth 1` to optimize the clones in _appveyor.yml_. Unfortunately, this has the side effect of fetching only the "default" branch, which causes problems when we are checking whether a similarly-named branch exists in _dc-law-xml-codified_ and deciding whether to switch to it (if it does exist) or create it (if it doesn't).

Adding the `--no-single-branch` lets us keep most of the optimization, but also fetches references to other branches, so that we can perform the check properly.