### PR TITLE
change badge links to point to renamed oll-team project

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 District of Columbia law (statutes and code) in XML format.
 
-_master_: [![Build status](https://ci.appveyor.com/api/projects/status/l9vfnxerqha83s03/branch/master?svg=true)](https://ci.appveyor.com/project/oll-bot/dc-law-xml/branch/master)
+_master_: [![Build status](https://ci.appveyor.com/api/projects/status/l9vfnxerqha83s03/branch/master?svg=true)](https://ci.appveyor.com/project/oll-team/dc-law-xml/branch/master)
 
-_development_: [![Build status](https://ci.appveyor.com/api/projects/status/l9vfnxerqha83s03/branch/development?svg=true)](https://ci.appveyor.com/project/oll-bot/dc-law-xml/branch/development)
+_development_: [![Build status](https://ci.appveyor.com/api/projects/status/l9vfnxerqha83s03/branch/development?svg=true)](https://ci.appveyor.com/project/oll-team/dc-law-xml/branch/development)
 
 
 # Branches


### PR DESCRIPTION
The badge images themselves are fine, but the links were pointing to the AppVeyor _oll-bot_ project, which has now been renamed to _oll-team_.

~This PR is being made to the _master_ branch because that is the default branch shown in GitHub (although that is configurable should we wish to violate conventional norms).~