### PR TITLE
only deploy to dc-law-xml-codified on master and development

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,10 @@ test_script:
   - echo Skipping doomed test discovery to save time
 
 deploy_script:
-  - cd ..\dc-law-xml-codified
-  - git add -A
-  - git diff --cached --exit-code --shortstat || git commit --quiet -m "deploy codified XML from dc-law-xml build %appveyor_build_version%"
-  - git push origin %appveyor_repo_branch%
+  - ps: >-
+      if ($env:appveyor_repo_branch -eq "master" -or $env:appveyor_repo_branch -eq "development") {
+        & cd ..\dc-law-xml-codified
+        & git add -A
+        (& git diff --cached --exit-code --shortstat) -or (& git commit --quiet -m "deploy codified XML from dc-law-xml build %appveyor_build_version%")
+        & git push origin %appveyor_repo_branch%
+      }


### PR DESCRIPTION
Skip deployment to _dc-law-xml-codified_ for other branches (but still run the rest of the build).