### PR TITLE
fix env vars in appveyor.yml PowerShell command

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,6 +54,6 @@ deploy_script:
       if ($env:appveyor_repo_branch -eq "master" -or $env:appveyor_repo_branch -eq "development") {
         & cd ..\dc-law-xml-codified
         & git add -A
-        (& git diff --cached --exit-code --shortstat) -or (& git commit --quiet -m "deploy codified XML from dc-law-xml build %appveyor_build_version%")
-        & git push origin %appveyor_repo_branch%
+        (& git diff --cached --exit-code --shortstat) -or (& git commit --quiet -m "deploy codified XML from dc-law-xml build $env:appveyor_build_version")
+        & git push origin $env:appveyor_repo_branch
       }


### PR DESCRIPTION
PR #58 broke the deployment in its conversion of `cmd` lines to PowerShell lines (environment variables are referenced differently); this is intended to fix that.