### PR TITLE
avoid PowerShell from raising an exception on success

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,5 +55,5 @@ deploy_script:
         & cd ..\dc-law-xml-codified
         & git add -A
         (& git diff --cached --exit-code --shortstat) -or (& git commit --quiet -m "deploy codified XML from dc-law-xml build $env:appveyor_build_version")
-        & git push origin $env:appveyor_repo_branch
+        & git push --porcelain origin $env:appveyor_repo_branch
       }


### PR DESCRIPTION
Per Feodor at AppVeyor:

> Git writes to StdErr which is interpreted as exception by PowerShell.

Per the `git` docs:

> --porcelain
>
> Produce machine-readable output. The output status line for each ref will be tab-separated and sent to stdout instead of stderr. The full symbolic names of the refs will be given.