### PR TITLE
replace broken PS, only deploy master/development DCCODE-218

### DIFF
--- a/appveyor-deploy.cmd
+++ b/appveyor-deploy.cmd
@@ -1,0 +1,14 @@
+:: deploy if we are on the master/development branch
+
+set deploy=no
+if "%appveyor_repo_branch%" == "master" set deploy=yes
+if "%appveyor_repo_branch%" == "development" set deploy=yes
+if "%deploy%" == "yes" (
+  cd ..\dc-law-xml-codified
+  git add -A
+  git diff --cached --exit-code --shortstat || git commit --quiet -m "deploy codified XML from dc-law-xml build %appveyor_build_version%"
+  git push origin %appveyor_repo_branch%
+  echo "deployed to %appveyor_repo_branch%"
+) else (
+  echo "skipping deployment"
+)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,10 +50,5 @@ test_script:
   - echo Skipping doomed test discovery to save time
 
 deploy_script:
-  - ps: >-
-      if ($env:appveyor_repo_branch -eq "master" -or $env:appveyor_repo_branch -eq "development") {
-        & cd ..\dc-law-xml-codified
-        & git add -A
-        (& git diff --cached --exit-code --shortstat) -or (& git commit --quiet -m "deploy codified XML from dc-law-xml build $env:appveyor_build_version")
-        & git push --porcelain origin $env:appveyor_repo_branch
-      }
+  - cd ..\dc-law-xml
+  - appveyor-deploy.cmd


### PR DESCRIPTION
None of us understands PowerShell well enough to properly maintain it, and the PowerShell script that I added to _appveyor.yml_ clearly wasn't doing it's job (of deploying on the _master_ and _development_ branches), so I went back to a CMD script. Unfortunately, AppVeyor doesn't support multiline CMD scripts properly, so I put the script in a new file (_appveyor-deploy.cmd_) and am calling that from _appveyor.yml_.

A working deploy was tested here: https://ci.appveyor.com/project/oll-team/dc-law-xml/build/1.0.356

The difference between that commit and this PR:
```diff
$ git diff d4809ca..2bd8fdb
diff --git a/appveyor-deploy.cmd b/appveyor-deploy.cmd
index fba86cd..7134421 100644
--- a/appveyor-deploy.cmd
+++ b/appveyor-deploy.cmd
@@ -3,7 +3,6 @@
 set deploy=no
 if "%appveyor_repo_branch%" == "master" set deploy=yes
 if "%appveyor_repo_branch%" == "development" set deploy=yes
-if "%appveyor_repo_branch%" == "DCCODE-218" set deploy=yes
 if "%deploy%" == "yes" (
   cd ..\dc-law-xml-codified
   git add -A
```