### PR TITLE
create tags in -codified and -html repos after build (#5)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,4 +56,4 @@ skip_tags: true   # don't create builds for tags (only for branches)
 
 deploy_script:
   - cd ..\dc-law-xml
-  - "%PYTHON%\\python.exe ..\\dc-law-tools\\appveyor-deploy\\dc-law-xml.py"
+  - "%PYTHON%\\python.exe -u ..\\dc-law-tools\\appveyor-deploy\\dc-law-xml.py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,8 @@ build_script:
 test_script:
   - echo Skipping doomed test discovery to save time
 
+skip_tags: true   # don't create builds for tags (only for branches)
+
 deploy_script:
   - cd ..\dc-law-xml
   - "%PYTHON%\\python.exe ..\\dc-law-tools\\appveyor-deploy\\dc-law-xml.py"


### PR DESCRIPTION
See details here: https://github.com/openlawlibrary/OpenLawPlatform/issues/5

*Note that this PR excludes the "test building" commit from the example above.*

Summary:
- do not trigger builds on tags (only on branches)
- show deploy messages unbuffered (better user experience when watching the AppVeyor builds)