### PR TITLE
Update appveyor script to run dotnet restore and build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,11 @@ before_build:
   - "%PYTHON%\\python.exe -m pip install wheel"
   - "%PYTHON%\\python.exe -m pip install    ..\\dc-law-tools\\requirements\\lxml-3.6.4-cp35-cp35m-win32.whl"
   - "%PYTHON%\\python.exe -m pip install -r ..\\dc-law-tools\\requirements.txt"
+  # dotnet restore and build
+  - ps: cd ..\dc-law-tools\dotnet
+  - dotnet restore
+  - dotnet build -f netcoreapp1.0 -c release
+  - ps: cd ..\..\dc-law-xml
 
 build_script:
   - cd ..\dc-law-tools


### PR DESCRIPTION
Don't merge until dotnet branch of dc-law-tools is merged into master per @augb 