### PR TITLE
Fix history cites,  add expiration

### DIFF
--- a/dc/council/code/titles/1/sections/1-1001.02.xml
+++ b/dc/council/code/titles/1/sections/1-1001.02.xml
@@ -257,7 +257,7 @@
     <annotation doc="D.C. Law 18-160" type="History">May 27, 2010, D.C. Law 18-160,§ 131(b), 57 DCR 3012</annotation>
     <annotation doc="D.C. Law 19-124" type="History">Apr. 27, 2012, D.C. Law 19-124, § 501(g)(1), 59 DCR 1862</annotation>
     <annotation doc="D.C. Law 20-31" type="History">Oct. 17, 2013, D.C. Law 20-31, § 2(a), 60 DCR 11535</annotation>
-    <annotation doc="D.C. Law 20-167" type="History">Mar. 3, 2015, D.C. Law 20-167, § 2(b), 61 DCR 10738</annotation>
+    <annotation doc="D.C. Law 20-167" type="History" eff="2015-03-03">Mar. 3, 2015, D.C. Law 20-167, § 2(b), 61 DCR 10738</annotation>
     <annotation type="Cross References">Advisory Neighborhood Commissions, “registered qualified elector” defined, see § <cite path="§1-309.09">1-309.09</cite>.</annotation>
     <annotation type="Cross References">Delegate to the House of Representatives, qualifications, see § <cite path="§1-401">1-401</cite>.</annotation>
     <annotation type="Section References">This section is referenced in § <cite path="§1-301.83">1-301.83</cite>, § <cite path="§1-309.09">1-309.09</cite>, § <cite path="§1-401">1-401</cite>, § <cite path="§1-1001.07">1-1001.07</cite>, and § <cite path="§38-2651">38-2651</cite>.</annotation>

--- a/dc/council/code/titles/1/sections/1-1001.07.xml
+++ b/dc/council/code/titles/1/sections/1-1001.07.xml
@@ -632,7 +632,7 @@
     <annotation doc="D.C. Law 17-236" type="History">Oct. 21, 2008, D.C. Law 17-236, § 2, 55 DCR 9019</annotation>
     <annotation doc="D.C. Law 18-103" type="History">Feb. 4, 2010, D.C. Law 18-103, § 2(e), 56 DCR 9169</annotation>
     <annotation doc="D.C. Law 19-131" type="History">May 31, 2012, D.C. Law 19-131,§ 2(a), 59 DCR 2389</annotation>
-    <annotation doc="D.C. Law 20-273" type="History">May 2, 2015, D.C. Law 20-273, § 2(b), 62 DCR 1938</annotation>
+    <annotation doc="D.C. Law 20-273" type="History" eff="2015-05-02">May 2, 2015, D.C. Law 20-273, § 2(b), 62 DCR 1938</annotation>
     <annotation type="Cross References">Advisory Neighborhood Commissions, “registered qualified elector” defined, see § <cite path="§1-309.09">1-309.09</cite>.</annotation>
     <annotation type="Section References">This section is referenced in § <cite path="§1-309.09">1-309.09</cite>, § <cite path="§1-1001.02">1-1001.02</cite>, § <cite path="§1-1001.05">1-1001.05</cite>, § <cite path="§1-1001.08">1-1001.08</cite>, and § <cite path="§1-1001.14">1-1001.14</cite>.</annotation>
     <annotation type="Prior Codifications">1981 Ed., § 1-1311.</annotation>

--- a/dc/council/code/titles/10/sections/10-1103.04.xml
+++ b/dc/council/code/titles/10/sections/10-1103.04.xml
@@ -70,7 +70,7 @@
     <annotation doc="D.C. Law 17-253" type="History">Oct. 22, 2008, D.C. Law 17-253, § 3, 55 DCR 9270</annotation>
     <annotation doc="D.C. Law 17-284" type="History">Dec. 24, 2008, D.C. Law 17-284, § 2(b), 55 DCR 11983</annotation>
     <annotation doc="D.C. Law 18-198" type="History">July 23, 2010, D.C. Law 18-198, § 4, 57 DCR 4528</annotation>
-    <annotation doc="D.C. Law 20-155" type="History">Feb. 26, 2015, D.C. Law 20-155, § 6002(d), 61 DCR 9990</annotation>
+    <annotation doc="D.C. Law 20-155" type="History" eff="2015-02-26">Feb. 26, 2015, D.C. Law 20-155, § 6002(d), 61 DCR 9990</annotation>
     <annotation type="Prior Codifications">1981 Ed., § 7-1010.</annotation>
     <annotation type="Prior Codifications">1973 Ed., § 7-911.</annotation>
     <annotation type="Effect of Amendments"><cite doc="D.C. Law 16-192">D.C. Law 16-192</cite> added subsec. (c).</annotation>

--- a/dc/council/code/titles/38/sections/38-2602.xml
+++ b/dc/council/code/titles/38/sections/38-2602.xml
@@ -408,7 +408,6 @@
     <annotation doc="D.C. Law 21-36" type="History">Oct. 22, 2015, D.C. Law 21-36, § 4142, 62 DCR 10905</annotation>
     <annotation doc="D.C. Law 21-44" type="History">Jan. 9, 2016, D.C. Law 21-44, § 3, 62 DCR 14236</annotation>
     <annotation doc="D.C. Law 21-74" type="History">Feb. 27, 2016, D.C. Law 21-74, § 4(a), 63 DCR 252</annotation>
-    <annotation doc="D.C. Law 21-77" type="History">Mar. 9, 2016, D.C. Law 21-77, § 3(b), 63 DCR 756</annotation>
     <annotation type="Cross References">Testing integrity, § <cite path="§38-771.01">38-771.01</cite> et seq.</annotation>
     <annotation type="Section References">This section is referenced in § <cite path="§38-208">38-208</cite>, § <cite path="§38-302">38-302</cite>, § <cite path="§38-771.02">38-771.02</cite>, § <cite path="§38-2602.01">38-2602.01</cite>, and § <cite path="§38-2603">38-2603</cite>.</annotation>
     <annotation type="Effect of Amendments"><cite doc="D.C. Law 15-39">D.C. Law 15-39</cite>, in subsec. (b), made nonsubstantive changes in pars. (4) and (5), and added par. (6)</annotation>

--- a/dc/council/periods/21/laws/21-120.xml
+++ b/dc/council/periods/21/laws/21-120.xml
@@ -156,7 +156,7 @@
       <text>New paragraphs (25), (26), and (27) are added to read as follows:</text>
       <include>
         <para>
-          <codify:insert/>
+          <codify:insert warning="false" technical="true"/>
           <num codify:value="(26)">(25)</num>
           <para>
             <num>(A)</num>

--- a/dc/council/periods/21/laws/21-160.xml
+++ b/dc/council/periods/21/laws/21-160.xml
@@ -3806,6 +3806,9 @@
               <text>Notwithstanding paragraph (1) of this subsection, the Executive Director as of <span codify:value="October 8, 2016">the effective date of this subtitle</span> shall be exempt from the residency requirement in paragraph (1) of this subsection.</text>
             </para>
           </para>
+          <annotation type="Expiration of Law">
+            Section 3127 of D.C. Law 21-160 provided that this section shall expire on October 1, 2018.
+          </annotation>
         </section>
         <section>
           <codify:insert num-value="3-152"/>
@@ -3899,6 +3902,9 @@
             <num>(f)</num>
             <text>The Commission may request such information as may be necessary to fulfill its statutory responsibilities.  Each department, agency, instrumentality, or independent agency of the District of Columbia is authorized and directed, to the extent permitted by law, to furnish the Commission with such requested information.</text>
           </para>
+          <annotation type="Expiration of Law">
+            Section 3127 of D.C. Law 21-160 provided that this section shall expire on October 1, 2018.
+          </annotation>
         </section>
         <section>
           <codify:insert num-value="3-153"/>
@@ -3960,6 +3966,9 @@
             <num>(f)</num>
             <text>The Commission shall compile and make publicly available a record of all written comments received from Advisory Group members under subsection (c) of this section.</text>
           </para>
+          <annotation type="Expiration of Law">
+            Section 3127 of D.C. Law 21-160 provided that this section shall expire on October 1, 2018.
+          </annotation>
         </section>
         <section>
           <codify:insert num-value="3-154"/>
@@ -3997,6 +4006,9 @@
               <text>A work plan and schedule, or revisions to an existing work plan and schedule, for carrying out the responsibilities of the Commission to meet statutory requirements.</text>
             </para>
           </para>
+          <annotation type="Expiration of Law">
+            Section 3127 of D.C. Law 21-160 provided that this section shall expire on October 1, 2018.
+          </annotation>
         </section>
         <section>
           <codify:insert num-value="3-155"/>
@@ -4010,6 +4022,9 @@
             <num>(b)</num>
             <text>All rules, orders, obligations, determinations, grants, contracts, licenses, and agreements of the Criminal Code Revision Project transferred to the Criminal Code Revision Commission under subsection (a) of this section shall continue in effect according to their terms until lawfully amended, repealed, or modified.</text>
           </para>
+          <annotation type="Expiration of Law">
+            Section 3127 of D.C. Law 21-160 provided that this section shall expire on October 1, 2018.
+          </annotation>
         </section>
         <section codify:expire="">
           <codify:insert num-value="3-156"/>
@@ -6556,6 +6571,9 @@
           <num>(5)</num>
           <text>"Outpatient gross patient revenue" means the amount calculated in accordance with generally accepted accounting principles for hospitals that is reported as the sum of Lines 18 and 19; Column 2; Worksheet G-2 of the Hospital and Hospital Health Care Complex Cost Report (Form CMS 2552-10), filed for the period ending between October 1, 2013, and September 30, 2014.</text>
         </para>
+        <annotation type="Expiration of Law">
+          Section 5070 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section>
         <codify:insert doc="D.C. Code" path="44|6A|II" num-value="44-661.12"/>
@@ -6608,6 +6626,9 @@
             <text>Subject to authorization in an approved budget and financial plan, any funds appropriated in the Fund shall be continually available without regard to fiscal year limitation.</text>
           </para>
         </para>
+        <annotation type="Expiration of Law">
+          Section 5070 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section>
         <codify:insert doc="D.C. Code" path="44|6A|II" num-value="44-661.13"/>
@@ -6633,6 +6654,9 @@
           <num>(b)</num>
           <text>A psychiatric hospital that is an agency or a unit of the District government is exempt from the fee imposed under subsection (a) of this section, unless the exemption is adjudged to be unconstitutional or otherwise invalid, in which case a psychiatric hospital that is an agency or a unit of the District government shall pay the fee imposed by subsection (a) of this section.</text>
         </para>
+        <annotation type="Expiration of Law">
+          Section 5070 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section>
         <codify:insert doc="D.C. Code" path="44|6A|II" num-value="44-661.14"/>
@@ -6662,6 +6686,9 @@
           <num>(d)</num>
           <text>Should the fee imposed by <code-cite doc="D.C. Law 21-160" path="§5064">section 5064</code-cite> not take effect or cease to be imposed, moneys in the Fund derived from the imposed fee shall be disbursed in accordance with <code-cite doc="D.C. Law 21-160" path="§5066">section 5066</code-cite> to the extent federal matching is available. If federal matching is not available due to a determination by the Centers for Medicare and Medicaid Services that the fee is impermissible, any remaining moneys shall be refunded to hospitals in proportion to the amounts paid by them.</text>
         </para>
+        <annotation type="Expiration of Law">
+          Section 5070 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section>
         <codify:insert doc="D.C. Code" path="44|6A|II" num-value="44-661.15"/>
@@ -6709,6 +6736,9 @@
           <num>(e)</num>
           <text>The Medicaid payment methodologies authorized under <code-cite doc="D.C. Law 21-160" path="V|G">this subtitle</code-cite> shall not be altered in any way unless such alteration is necessary to gain federal approval from the Centers for Medicare and Medicaid Services.</text>
         </para>
+        <annotation type="Expiration of Law">
+          Section 5070 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section>
         <codify:insert doc="D.C. Code" path="44|6A|II" num-value="44-661.16"/>
@@ -6741,6 +6771,9 @@
           <num>(c)</num>
           <text>The payment by the hospital of the fee created in <code-cite doc="D.C. Law 21-160" path="V|G">this subtitle</code-cite> shall be reported as an allowable cost for purposes of Medicaid hospital reimbursement.</text>
         </para>
+        <annotation type="Expiration of Law">
+          Section 5070 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section>
         <codify:insert doc="D.C. Code" path="44|6A|II" num-value="44-661.17"/>
@@ -6765,12 +6798,18 @@
           <num>(c)</num>
           <text>Notwithstanding any other provision in <code-cite doc="D.C. Law 21-160" path="V|G">this subtitle</code-cite>, a hospital system or person who conducts, operates, or maintains a hospital, upon notice by the Department, shall pay the fee computed under <code-cite doc="D.C. Law 21-160" path="§5064">section 5064</code-cite> and subsection (a) of this section in installments on the due date stated in the notice and on the regular installment due dates for the DFY occurring after the due dates of the initial notice.</text>
         </para>
+        <annotation type="Expiration of Law">
+          Section 5070 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section>
         <codify:insert doc="D.C. Code" path="44|6A|II" num-value="44-661.18"/>
         <num>5069</num>
         <heading>Rules.</heading>
         <text>The Mayor, pursuant to <code-cite doc="Pub. L. 90-614" path="I">Title I of the District of Columbia Administrative Procedure Act, approved October 21, 1968 (82 Stat. 1204; D.C. Official Code § 2-501 <em>et seq</em>.)</code-cite>, may issue rules to implement the provisions of <code-cite doc="D.C. Law 21-160" path="V|G">this subtitle</code-cite>.</text>
+        <annotation type="Expiration of Law">
+          Section 5070 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section codify:expire="">
         <codify:insert doc="D.C. Code" path="44|6A|II" num-value="44-661.19"/>
@@ -6839,6 +6878,9 @@
           <num>(5)</num>
           <text>"Medicaid" means the medical assistance programs authorized by Title XIX of the Social Security Act, approved July 30, 1965 (79 Stat. 343; 42 U.S.C. § 1396 <em>et seq</em>.) ("Social Security Act"), and by <code-cite doc="Pub. L. 90-227" path="§1">section 1 of An Act To enable the District of Columbia to receive Federal financial assistance under title XIX of the Social Security Act for a medical assistance program, and for other purposes, approved December 27, 1967 (81 Stat. 744; D.C. Official Code § 1-307.02)</code-cite>, and administered by the Department.</text>
         </para>
+        <annotation type="Expiration of Law">
+          Section 5079 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section>
         <codify:insert doc="D.C. Code" path="44|6D|II" num-value="44-662.12"/>
@@ -6879,6 +6921,9 @@
             <text>Subject to authorization in an approved budget and financial plan, any funds appropriated in the Fund shall be continually available without regard to fiscal year limitation; provided, that any remaining money in the Fund at the end of each fiscal year shall be refunded to hospitals in proportion to the amounts paid by them.</text>
           </para>
         </para>
+        <annotation type="Expiration of Law">
+          Section 5079 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section>
         <codify:insert doc="D.C. Code" path="44|6D|II" num-value="44-662.13"/>
@@ -6907,6 +6952,9 @@
           <num>(c)</num>
           <text>If necessary, by August 1, 2016, the Department shall submit a provider tax waiver application to the Center for Medicare and Medicaid Services to ensure the provisions of <code-cite doc="D.C. Law 21-160" path="V|H">this subtitle</code-cite> qualify as a broad-based health care related tax, as that term is defined in section 1903(w)(3)(B) of the Social Security Act.</text>
         </para>
+        <annotation type="Expiration of Law">
+          Section 5079 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section>
         <codify:insert doc="D.C. Code" path="44|6D|II" num-value="44-662.14"/>
@@ -6935,6 +6983,9 @@
           <num>(d)</num>
           <text>The payment by the hospital of the fee created in <code-cite doc="D.C. Law 21-160" path="V|H">this subtitle</code-cite> shall be reported as an allowable cost for purposes of Medicaid hospital reimbursement.</text>
         </para>
+        <annotation type="Expiration of Law">
+          Section 5079 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section>
         <codify:insert doc="D.C. Code" path="44|6D|II" num-value="44-662.15"/>
@@ -6959,6 +7010,9 @@
           <num>(c)</num>
           <text>Notwithstanding any other provision of <code-cite doc="D.C. Law 21-160" path="V|H">this subtitle</code-cite>, a hospital system or person who conducts, operates, or maintains a hospital, upon notice by the Department, shall pay the fee required under <code-cite path="§5074">5074</code-cite> in accordance with subsection (a) of this section on the due date stated in the notice and on the regular installment due dates for the DFY occurring after the due date of the initial notice.</text>
         </para>
+        <annotation type="Expiration of Law">
+          Section 5079 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section>
         <codify:insert doc="D.C. Code" path="44|6D|II" num-value="44-662.16"/>
@@ -6972,12 +7026,18 @@
           <num>(b)</num>
           <text>If the Centers for Medicare and Medicaid Services determines that an exclusion for specialty hospitals under <code-cite doc="D.C. Law 21-160" path="V|H">this subtitle</code-cite> would prevent an assessment imposed by <code-cite doc="D.C. Law 21-160" path="V|H">this subtitle</code-cite> from qualifying as a broad-based health care related tax, as that term is defined in section 1903(w)(3)(B) of the Social Security Act, the exclusion of specialty hospitals shall not be made.</text>
         </para>
+        <annotation type="Expiration of Law">
+          Section 5079 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section>
         <codify:insert doc="D.C. Code" path="44|6D|II" num-value="44-662.17"/>
         <num>5078</num>
         <heading>Rules.</heading>
         <text>The Mayor, pursuant to <code-cite doc="Pub. L. 90-614" path="I">Title I of the District of Columbia Administrative Procedure Act, approved October 21, 1968 (82 Stat. 1204; D.C. Official Code § 2-501 <em>et seq</em>.)</code-cite>, may issue rules to implement the provisions of <code-cite doc="D.C. Law 21-160" path="V|H">this subtitle</code-cite>.</text>
+        <annotation type="Expiration of Law">
+          Section 5079 of D.C. Law 21-160 provided that this section shall expire on September 30, 2017.
+        </annotation>
       </section>
       <section codify:expire="">
         <codify:insert doc="D.C. Code" path="44|6D|II" num-value="44-662.18"/>
@@ -8856,7 +8916,7 @@
               <text>On or before March 30, 2018, the Department shall submit a written report to the Council that evaluates the pilot program's operations, including the number of vehicles inspected, a description of issues that arose during the reporting period, and a study of the impact of the pilot program on the number of vehicles inspected and wait times at non-self-service inspection stations.</text>
             </para>
             <annotation type="Expiration of Law">
-              Section 6143 of D.C. Law 21-160 provided that this section shall expire on September 30, 2018
+              Section 6143 of D.C. Law 21-160 provided that this section shall expire on September 30, 2018.
             </annotation>
           </section>
         </include>

--- a/dc/council/periods/21/laws/21-160.xml
+++ b/dc/council/periods/21/laws/21-160.xml
@@ -2156,6 +2156,9 @@
               <num>(g)</num>
               <text>By November 1, 2016, the Mayor, pursuant to <code-cite doc="Pub. L. 90-614" path="I">Title I of the District of Columbia Administrative Procedure Act, approved October 21, 1968 (82 Stat. 1204; D.C. Official Code § 2-501 <em>et seq.</em>)</code-cite>, shall issue rules to implement the provisions of this section. The rules shall mandate processes for the application for, and distribution of, funds in a timely manner so as to facilitate successful compliance with the required timelines and purposes of this section.</text>
             </para>
+            <annotation type="Expiration of Law">
+              Pursuant to section 2124 of D.C. Law 21-160, the addition of this section by section 2122 of D.C. Law 21-160 will expire on September 30, 2017.
+            </annotation>
           </section>
         </include>
         <aftertext>.</aftertext>
@@ -2191,17 +2194,15 @@
           </include>
           <aftertext>.</aftertext>
         </para>
+        <annotation type="Expiration of Law">
+          Pursuant to section 2124 of D.C. Law 21-160, the amendment made to this section by section 2123 of D.C. Law 21-160 will expire on September 30, 2017.
+        </annotation>
       </section>
-      <section>
+      <section codify:expire="">
         <num>2124</num>
         <heading>Sunset.</heading>
         <text>This subtitle shall expire on September 30, 2017.</text>
-        <codify:annotation doc="D.C. Code" path="§42-3404.14" type="Expiration of Law" history="false">
-          Pursuant to section 2124 of D.C. Law 21-160, the addition of this section by section 2122 of D.C. Law 21-160 will expire on September 30, 2017.
-        </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§42-2857.01" type="Expiration of Law" history="false">
-          Pursuant to section 2124 of D.C. Law 21-160, the amendment made to this section by section 2123 of D.C. Law 21-160 will expire on September 30, 2017.
-        </codify:annotation>
+        <codify:expire path="II|M" date="2017-09-30"/>
       </section>
     </container>
     <container>
@@ -3083,6 +3084,9 @@
                 </para>
               </include>
               <aftertext>.</aftertext>
+              <annotation type="Expiration of Law">
+                Section 3073 of D.C. Law 21-160 provided that section 3072(a)(2)(C) and (3) of D.C. Law 21-160 shall expire on September 30, 2019.
+              </annotation>
             </para>
           </para>
           <para>
@@ -3253,13 +3257,11 @@
           <aftertext>.</aftertext>
         </para>
       </section>
-      <section>
+      <section codify:expire="">
         <num>3073</num>
         <heading>Sunset.</heading>
         <text>Section 3072(a)(2)(C) and (3) shall expire on September 30, 2019.</text>
-        <codify:annotation path="§3072|(a)|(2)|(C)" type="Expiration of Law" history="false">
-          Section 3073 of D.C. Law 21-160 provided that section 3072(a)(2)(C) and (3) of D.C. Law 21-160 shall expire on September 30, 2019.
-        </codify:annotation>
+        <codify:expire path="§3072|(a)|(2)|(C)" date="2019-09-30"/>
       </section>
     </container>
     <container>
@@ -4009,11 +4011,12 @@
             <text>All rules, orders, obligations, determinations, grants, contracts, licenses, and agreements of the Criminal Code Revision Project transferred to the Criminal Code Revision Commission under subsection (a) of this section shall continue in effect according to their terms until lawfully amended, repealed, or modified.</text>
           </para>
         </section>
-        <section>
+        <section codify:expire="">
           <codify:insert num-value="3-156"/>
           <num>3127</num>
           <heading>Sunset.</heading>
           <text><code-cite doc="D.C. Code" path="|3|1A">This part</code-cite> shall expire on October 1, 2018.</text>
+          <codify:expire doc="D.C. Law 21-160" path="III|M|1" date="2018-10-01"/>
         </section>
       </container>
       <container>
@@ -6769,11 +6772,12 @@
         <heading>Rules.</heading>
         <text>The Mayor, pursuant to <code-cite doc="Pub. L. 90-614" path="I">Title I of the District of Columbia Administrative Procedure Act, approved October 21, 1968 (82 Stat. 1204; D.C. Official Code § 2-501 <em>et seq</em>.)</code-cite>, may issue rules to implement the provisions of <code-cite doc="D.C. Law 21-160" path="V|G">this subtitle</code-cite>.</text>
       </section>
-      <section>
+      <section codify:expire="">
         <codify:insert doc="D.C. Code" path="44|6A|II" num-value="44-661.19"/>
         <num>5070</num>
         <heading>Sunset.</heading>
         <text><code-cite doc="D.C. Law 21-160" path="V|G">This subtitle</code-cite> shall expire on September 30, 2017.</text>
+        <codify:expire doc="D.C. Law 21-160" path="V|G" date="2017-09-30"/>
       </section>
     </container>
     <codify:create-sub-container doc="D.C. Code" path="44|6D" num-value="I" prefix-value="Subchapter" heading-value="2015-2016 Supplement." history="false"/>
@@ -6975,11 +6979,12 @@
         <heading>Rules.</heading>
         <text>The Mayor, pursuant to <code-cite doc="Pub. L. 90-614" path="I">Title I of the District of Columbia Administrative Procedure Act, approved October 21, 1968 (82 Stat. 1204; D.C. Official Code § 2-501 <em>et seq</em>.)</code-cite>, may issue rules to implement the provisions of <code-cite doc="D.C. Law 21-160" path="V|H">this subtitle</code-cite>.</text>
       </section>
-      <section>
+      <section codify:expire="">
         <codify:insert doc="D.C. Code" path="44|6D|II" num-value="44-662.18"/>
         <num>5079</num>
         <heading>Sunset.</heading>
         <text><code-cite doc="D.C. Law 21-160" path="V|H">This subtitle</code-cite> shall expire on September 30, 2017.</text>
+        <codify:expire doc="D.C. Law 21-160" path="V|H" date="2017-09-30"/>
       </section>
     </container>
     <container>
@@ -7093,19 +7098,20 @@
           <num>(f)</num>
           <text>For the purposes of this section, the term "Individualized Success Plans" includes plans developed by the youth, family members, and agency staff that describe the services the youth needs, such as tutoring, job training, or substance abuse prevention, and the progress the youth needs to make.</text>
         </para>
-        <codify:annotation doc="D.C. Code" path="§2-1591" type="Editor's Notes" history="false">
+        <annotation doc="D.C. Code" path="§2-1591" type="Editor's Notes" history="false">
           For temporary establishment of Youth Services Cooridinating Task Force, see <cite doc="D.C. Law 21-160" path="§5092">sections 5092 through 5094 of D.C. Law 21-160</cite>.
-        </codify:annotation>
+        </annotation>
       </section>
       <section>
         <num>5093</num>
         <heading>Administration and appropriations.</heading>
         <text>The Office of the Deputy Mayor for Health and Human Services shall provide facilities and other administrative support for the Task Force.</text>
       </section>
-      <section>
+      <section codify:expire="">
         <num>5094</num>
         <heading>Sunset.</heading>
         <text>This subtitle shall expire on March 17, 2017.</text>
+        <codify:expire path="V|J" date="2017-03-17"/>
       </section>
     </container>
     <container>
@@ -8849,17 +8855,18 @@
               <num>(e)</num>
               <text>On or before March 30, 2018, the Department shall submit a written report to the Council that evaluates the pilot program's operations, including the number of vehicles inspected, a description of issues that arose during the reporting period, and a study of the impact of the pilot program on the number of vehicles inspected and wait times at non-self-service inspection stations.</text>
             </para>
+            <annotation type="Expiration of Law">
+              Section 6143 of D.C. Law 21-160 provided that this section shall expire on September 30, 2018
+            </annotation>
           </section>
         </include>
         <aftertext>.</aftertext>
       </section>
-      <section>
+      <section codify:expire="">
         <num>6143</num>
         <heading>Sunset.</heading>
         <text>This subtitle shall expire on September 30, 2018.</text>
-        <codify:annotation doc="D.C. Code" path="§50-1110" type="Expiration of Law">
-          Section 6143 of D.C. Law 21-160 provided that this section shall expire on September 30, 2018
-        </codify:annotation>
+        <codify:expire path="VI|M" date="2018-09-30"/>
       </section>
     </container>
     <container>

--- a/dc/council/periods/21/laws/21-160.xml
+++ b/dc/council/periods/21/laws/21-160.xml
@@ -3262,6 +3262,7 @@
         <heading>Sunset.</heading>
         <text>Section 3072(a)(2)(C) and (3) shall expire on September 30, 2019.</text>
         <codify:expire path="§3072|(a)|(2)|(C)" date="2019-09-30"/>
+        <codify:expire path="§3072|(a)|(3)" date="2019-09-30"/>
       </section>
     </container>
     <container>

--- a/dc/council/periods/21/laws/21-77.xml
+++ b/dc/council/periods/21/laws/21-77.xml
@@ -256,7 +256,7 @@
         <text>A new paragraph (24) is added to read as follows:</text>
         <include>
           <para>
-            <codify:insert after="(24)" num-value="(24A)"/>
+            <codify:insert after="(24)" num-value="(25)" technical="true"/>
             <num>(24)</num>
             <text>Procure, distribute, and maintain the undesignated epinephrine auto-injector supply and fulfill its other responsibilities as required by <code-cite doc="D.C. Code" path="|38|6|IV">the Student Access to Treatment Act of 2007, effective February 2, 2008 (D.C. Law 17-107; D.C. Official Code § 38-651.01 <em>et seq.</em>)</code-cite>.</text>
           </para>

--- a/schemas/codify.xsd
+++ b/schemas/codify.xsd
@@ -29,12 +29,14 @@
   </xs:element>
   <xs:attribute name="applicability" type="xs:string"/>
   <xs:attribute name="doc" type="xs:string"/>
+  <xs:attribute name="expire" type="xs:string"/>
   <xs:attribute name="instruction" type="xs:string"/>
   <xs:attribute name="path" type="xs:string"/>
   <xs:attribute name="value" type="xs:string"/>
   <xs:attributeGroup name="allAttributes">
     <xs:attribute ref="applicability" use="optional" />
     <xs:attribute ref="doc" use="optional" />
+    <xs:attribute ref="expire" use="optional"/>
     <xs:attribute ref="instruction" use="optional" />
     <xs:attribute ref="path" use="optional" />
     <xs:attribute ref="value" use="optional" />


### PR DESCRIPTION
Fix order of history citations. Add codify:expire instructions to 21-160 and add associated annotations regarding expiration.