### PR TITLE
Add `projected` attribute to `<meta>` `<effective>`.

### DIFF
--- a/dc/council/code/index.xml
+++ b/dc/council/code/index.xml
@@ -2,7 +2,7 @@
 <document xmlns="https://code.dccouncil.us/schemas/dc-library" xmlns:codified="https://code.dccouncil.us/schemas/codified" xmlns:codify="https://code.dccouncil.us/schemas/codify" xmlns:xi="http://www.w3.org/2001/XInclude" id="D.C. Code">
   <heading>Code of the District of Columbia</heading>
   <meta>
-    <effective>0000-00-00</effective>
+    <effective>0001-01-01</effective>
     <recency>
       <law>
         <law>21-84</law>

--- a/dc/council/periods/9/laws/9-97.xml
+++ b/dc/council/periods/9/laws/9-97.xml
@@ -3,7 +3,7 @@
   <num type="law">9-97</num>
   <heading type="short">Merchant’s Civil Recovery for Criminal Conduct Temporary Act of 1991</heading>
   <meta>
-    <effective/>
+    <effective>1992-05-07</effective>
     <citations>
       <citation type="law" url="./docs/9-97.pdf">D.C. Law 9-97</citation>
     </citations>

--- a/dc/council/revised-statutes.xml
+++ b/dc/council/revised-statutes.xml
@@ -2,7 +2,7 @@
 <document xmlns="https://code.dccouncil.us/schemas/dc-library" xmlns:codified="https://code.dccouncil.us/schemas/codified" xmlns:codify="https://code.dccouncil.us/schemas/codify" xmlns:xi="http://www.w3.org/2001/XInclude" id="R.S., D.C." url="/dc/council/revised-statutes.html">
   <heading>Revised Statutes of the District of Columbia</heading>
   <meta>
-    <effective>0000-00-02</effective>
+    <effective>0001-01-03</effective>
     <citations>
       <citation>R.S., D.C.</citation>
     </citations>

--- a/schemas/dc-library.xsd
+++ b/schemas/dc-library.xsd
@@ -173,6 +173,15 @@
       <xs:attributeGroup ref="codify:allAttributes"/>
     </xs:complexType>
   </xs:element>
+  <xs:element name="effective">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="date-or-empty">
+          <xs:attribute name="projected" type="xs:boolean" use="optional"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="page">
     <xs:complexType>
       <xs:attribute name="citation" type="xs:string" use="required"/>
@@ -217,7 +226,7 @@
   <xs:element name="meta">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="effective" type="xs:string" minOccurs="0"/>
+        <xs:element ref="effective" minOccurs="0"/>
         <xs:element name="temporary" type="xs:string" minOccurs="0"/>
         <xs:element name="recency" minOccurs="0">
           <xs:complexType>
@@ -271,7 +280,6 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-
   <xs:element name="num">
     <xs:complexType>
       <xs:simpleContent>
@@ -365,6 +373,14 @@
       <xs:attributeGroup ref="codify:allAttributes"/>
     </xs:complexType>
   </xs:element>
+  <xs:simpleType name="date-or-empty">
+    <xs:union memberTypes="xs:date empty-string"/>
+  </xs:simpleType>
+  <xs:simpleType name="empty-string">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+    </xs:restriction>
+  </xs:simpleType>
   <xs:complexType name="tocContainer">
     <xs:sequence>
       <xs:element ref="prefix" minOccurs="0"/>

--- a/us/congress/revised-statutes.xml
+++ b/us/congress/revised-statutes.xml
@@ -2,7 +2,7 @@
 <document xmlns="https://code.dccouncil.us/schemas/dc-library" xmlns:codified="https://code.dccouncil.us/schemas/codified" xmlns:codify="https://code.dccouncil.us/schemas/codify" xmlns:xi="http://www.w3.org/2001/XInclude" id="R.S., U.S." url="/us/congress/revised-statutes.html">
   <heading>Revised Statutes of the United States</heading>
   <meta>
-    <effective>0000-00-01</effective>
+    <effective>0001-01-02</effective>
     <citations>
       <citation>R.S., U.S.</citation>
     </citations>


### PR DESCRIPTION
Required for [support enacted but not-yet-law acts](https://github.com/openlawlibrary/open-law-codify/issues/80).