### PR TITLE
Codify schema updates

### DIFF
--- a/dc/council/periods/21/laws/21-154.xml
+++ b/dc/council/periods/21/laws/21-154.xml
@@ -74,7 +74,7 @@
           <para>
             <num>(ii)</num>
             <text>Strike the period and insert a semicolon in its place.</text>
-            <codify:find-replace path="(13)" find="." replace=";" location="last"/>
+            <codify:find-replace path="(13)" find="." replace=";" position="last"/>
           </para>
         </para>
         <para>

--- a/dc/council/periods/21/laws/21-160.xml
+++ b/dc/council/periods/21/laws/21-160.xml
@@ -4051,7 +4051,7 @@
             <para>
               <num>(1)</num>
               <text>The section heading is amended by striking the phrase "and Criminal Code Revision".</text>
-              <codify:find-replace position="heading" count="1">
+              <codify:find-replace path="heading" count="1">
                 <find>and Criminal Code Revision</find>
                 <replace/>
               </codify:find-replace>
@@ -4219,7 +4219,7 @@
           <para>
             <num>(1)</num>
             <text>The lead-in language is amended by striking the number "4" and inserting the number "5" in its place.</text>
-            <codify:find-replace position="text" count="1">
+            <codify:find-replace count="1" path="text">
               <find>4</find>
               <replace>5</replace>
             </codify:find-replace>
@@ -4579,7 +4579,7 @@
         <para>
           <num>(a)</num>
           <text>Section 104 (D.C. Official Code § 38-2903) is amended by striking the phrase "$9,492 per student for fiscal year 2015" and inserting the phrase "$9,682 per student for Fiscal Year 2017" in its place.</text>
-          <codify:find-replace position="text" path="§104" count="1">
+          <codify:find-replace path="§104" count="1">
             <find>$ 9,492 per student for Fiscal Year 2015</find>
             <replace>$9,682 per student for Fiscal Year 2017</replace>
           </codify:find-replace>
@@ -4851,7 +4851,7 @@
           <para>
             <num>(1)</num>
             <text>Strike the phrase "Fiscal Year 2017" and insert the phrase "Fiscal Year 2020" in its place.</text>
-            <codify:find-replace position="text" count="1">
+            <codify:find-replace count="1">
               <find>Fiscal Year 2017</find>
               <replace>Fiscal Year 2020</replace>
             </codify:find-replace>
@@ -7677,7 +7677,7 @@
             </section>
           </include>
           <aftertext>.</aftertext>
-          <codify:find-replace position="heading" count="1">
+          <codify:find-replace path="heading" count="1">
             <find>Fees for vital records and searches.</find>
             <replace>Vital records fees and fund.</replace>
           </codify:find-replace>
@@ -10402,7 +10402,7 @@
         <para>
           <num>(e)</num>
           <text>Section 2-2505 (D.C. Official Code § 3-1305) is amended by striking the phrase "No member of the Board, Chairperson of the Board, Executive Director, or employee of the Board" and inserting the phrase "Neither the Executive Director nor any employee of the Office" in its place.</text>
-          <codify:find-replace codify:doc="D.C. Code" path="§3-1305" count="1">
+          <codify:find-replace doc="D.C. Code" path="§3-1305" count="1">
             <find>No member of the Board, Chairperson of the Board, Executive Director, or employee of the Board</find>
             <replace>Neither the Executive Director nor any employee of the Office</replace>
           </codify:find-replace>
@@ -10620,7 +10620,7 @@
           <para>
             <num>(1)</num>
             <text>The first sentence is amended by striking the phrase "The Board shall" and inserting the phrase "The Office shall" in its place.</text>
-            <codify:find-replace count="1" location="first">
+            <codify:find-replace count="1" position="first">
               <find>The Board shall operate</find>
               <replace>The Office shall operate</replace>
             </codify:find-replace>

--- a/dc/council/periods/21/laws/21-192.xml
+++ b/dc/council/periods/21/laws/21-192.xml
@@ -69,17 +69,17 @@
       <para>
         <num>(1)</num>
         <text>The section heading is amended by striking the word "Non-Repairable" and inserting the word "Junk" in its place.</text>
-        <codify:find-replace find="Non-repairable" replace="Junk" codify:path="heading" count="1"/>
+        <codify:find-replace find="Non-repairable" replace="Junk" path="heading" count="1"/>
       </para>
       <para>
         <num>(2)</num>
         <text>Subsection (b) is amended by striking the word "Non-Repairable" both times it appears and inserting the word "Junk" in its place.</text>
-        <codify:find-replace find="Non-repairable" replace="Junk" codify:path="(b)" count="2"/>
+        <codify:find-replace find="Non-repairable" replace="Junk" path="(b)" count="2"/>
       </para>
       <para>
         <num>(3)</num>
         <text>Subsection (c) is amended by striking the word "Non-Repairable" both times it appears and inserting the word "Junk" in its place.</text>
-        <codify:find-replace find="Non-repairable" replace="Junk" codify:path="(c)" count="2"/>
+        <codify:find-replace find="Non-repairable" replace="Junk" path="(c)" count="2"/>
       </para>
       <para>
         <num>(4)</num>
@@ -87,7 +87,7 @@
         <para>
           <num>(A)</num>
           <text>Paragraph (1) is amended by striking the word "Non-Repairable" both times it appears and inserting the word "Junk" in its place.</text>
-          <codify:find-replace find="Non-repairable" replace="Junk" codify:path="(d)|(1)" count="2"/>
+          <codify:find-replace find="Non-repairable" replace="Junk" path="(d)|(1)" count="2"/>
         </para>
         <para>
           <num>(B)</num>
@@ -95,24 +95,24 @@
           <para>
             <num>(i)</num>
             <text>The lead-in language is amended by striking the word "Non-Repairable" and inserting the word "Junk" in its place.</text>
-            <codify:find-replace find="Non-repairable" replace="Junk" codify:path="(d)|(2)|text" count="1"/>
+            <codify:find-replace find="Non-repairable" replace="Junk" path="(d)|(2)|text" count="1"/>
           </para>
           <para>
             <num>(ii)</num>
             <text>Subparagraph (A) is amended by striking the word "Non-Repairable" and inserting the word "Junk" in its place.</text>
-            <codify:find-replace find="Non-repairable" replace="Junk" codify:path="(d)|(2)|(A)" count="1"/>
+            <codify:find-replace find="Non-repairable" replace="Junk" path="(d)|(2)|(A)" count="1"/>
           </para>
         </para>
       </para>
       <para>
         <num>(5)</num>
         <text>Subsection (e) is amended by striking the word "Non-Repairable" and inserting the word "Junk" in its place.</text>
-        <codify:find-replace find="Non-repairable" replace="Junk" codify:path="(e)" count="1"/>
+        <codify:find-replace find="Non-repairable" replace="Junk" path="(e)" count="1"/>
       </para>
       <para>
         <num>(6)</num>
         <text>Subsection (f) is amended by striking the word "Non-Repairable" both times it appears and inserting the word "Junk" in its place.</text>
-        <codify:find-replace find="Non-repairable" replace="Junk" codify:path="(f)" count="2"/>
+        <codify:find-replace find="Non-repairable" replace="Junk" path="(f)" count="2"/>
       </para>
     </para>
     <para codify:doc="D.C. Code" codify:path="§50-1331.04">
@@ -121,17 +121,17 @@
       <para>
         <num>(1)</num>
         <text>The section heading is amended by striking the word "Non-Repairable" and inserting the word "Junk" in its place.</text>
-        <codify:find-replace find="non-repairable" replace="Junk" codify:path="heading" count="1"/>
+        <codify:find-replace find="non-repairable" replace="Junk" path="heading" count="1"/>
       </para>
       <para>
         <num>(2)</num>
         <text>Subsection (a) is amended by striking the word "Non-repairable" both times it appears and inserting the word "Junk" in its place.</text>
-        <codify:find-replace find="Non-repairable" replace="Junk" codify:path="(a)" count="2"/>
+        <codify:find-replace find="Non-repairable" replace="Junk" path="(a)" count="2"/>
       </para>
       <para>
         <num>(3)</num>
         <text>Subsection (d) is amended by striking the phrase "salvage or non-repairable vehicle title" and inserting the phrase "Salvage Title or Junk Vehicle Certificate" in its place.</text>
-        <codify:find-replace find="salvage or non-repairable vehicle title" replace="Salvage Title or Junk Vehicle Certificate" codify:path="(d)" count="1"/>
+        <codify:find-replace find="salvage or non-repairable vehicle title" replace="Salvage Title or Junk Vehicle Certificate" path="(d)" count="1"/>
       </para>
     </para>
     <para codify:doc="D.C. Code" codify:path="§50-1331.07">
@@ -140,22 +140,22 @@
       <para>
         <num>(1)</num>
         <text>The section heading is amended by striking the word "Non-Repairable" and inserting the word "Junk" in its place.</text>
-        <codify:find-replace find="Non-repairable" replace="Junk" codify:path="heading" count="1"/>
+        <codify:find-replace find="Non-repairable" replace="Junk" path="heading" count="1"/>
       </para>
       <para>
         <num>(2)</num>
         <text>Subsection (a) is amended by striking the word "Non-Repairable" and inserting the word "Junk" in its place.</text>
-        <codify:find-replace find="Non-repairable" replace="Junk" codify:path="(a)" count="1"/>
+        <codify:find-replace find="Non-repairable" replace="Junk" path="(a)" count="1"/>
       </para>
       <para>
         <num>(3)</num>
         <text>Subsection (b) is amended by striking the word "Non-Repairable" and inserting the word "Junk" in its place.</text>
-        <codify:find-replace find="Non-repairable" replace="Junk" codify:path="(b)" count="1"/>
+        <codify:find-replace find="Non-repairable" replace="Junk" path="(b)" count="1"/>
       </para>
       <para>
         <num>(4)</num>
         <text>Subsection (c) is amended by striking the word "Non-Repairable" both times it appears and inserting the word "Junk" in its place.</text>
-        <codify:find-replace find="Non-repairable" replace="Junk" codify:path="(c)" count="2"/>
+        <codify:find-replace find="Non-repairable" replace="Junk" path="(c)" count="2"/>
       </para>
     </para>
     <para codify:doc="D.C. Code" codify:path="§50-1331.08|(a)">
@@ -164,12 +164,12 @@
       <para>
         <num>(1)</num>
         <text>Paragraph (2)(B) is amended by striking the word "Non-Repairable" and inserting the word "Junk" in its place.</text>
-        <codify:find-replace find="Non-repairable" replace="Junk" codify:path="(2)|(B)" count="1"/>
+        <codify:find-replace find="Non-repairable" replace="Junk" path="(2)|(B)" count="1"/>
       </para>
       <para>
         <num>(2)</num>
         <text>Paragraph (4) is amended by striking the word "Non-Repairable" and inserting the word "Junk" in its place.</text>
-        <codify:find-replace find="Non-repairable" replace="Junk" codify:path="(4)" count="1"/>
+        <codify:find-replace find="Non-repairable" replace="Junk" path="(4)" count="1"/>
       </para>
     </para>
   </section>
@@ -184,7 +184,7 @@
     <para codify:doc="D.C. Code" codify:path="§50-1331.08|(a)">
       <num>(a)</num>
       <text>Section 6(j)(3)(Q) (D.C. Official Code § 50-2201.03(j)(3)(Q)) is amended by striking the word "non-repairable" and inserting the word "junk" in its place.</text>
-      <codify:find-replace find="non-repairable" replace="junk" codify:path="§50-2201.03|(j)|(3)|(Q)" count="1"/>
+      <codify:find-replace find="non-repairable" replace="junk" path="§50-2201.03|(j)|(3)|(Q)" count="1"/>
     </para>
     <para codify:doc="D.C. Code" codify:path="§50-1401.01|(a)|(2)">
       <num>(b)</num>

--- a/dc/council/periods/21/laws/21-194.xml
+++ b/dc/council/periods/21/laws/21-194.xml
@@ -107,7 +107,7 @@
         <para>
           <num>(A)</num>
           <text>Paragraph (3) is amended by striking the phrase "or to the Robert F. Kennedy Memorial Stadium".</text>
-          <codify:find-replace codify:doc="D.C. Code" path="§7-1703|(a)|(3)" count="1">
+          <codify:find-replace doc="D.C. Code" path="§7-1703|(a)|(3)" count="1">
             <find>or to the Robert F. Kennedy Memorial Stadium</find>
             <replace/>
           </codify:find-replace>
@@ -115,7 +115,7 @@
         <para>
           <num>(B)</num>
           <text>Paragraph (4) is amended by striking the phrase "except as provided in section 3(1)" and inserting the phrase "except as provided in section 3(1A)" in its place.</text>
-          <codify:find-replace codify:doc="D.C. Code" path="§7-1703|(a)|(4)" count="1">
+          <codify:find-replace doc="D.C. Code" path="§7-1703|(a)|(4)" count="1">
             <find>in § <cite path="§7-1702">7-1702</cite>(1)</find>
             <replace>in § <cite path="§7-1702">7-1702(1A)</cite></replace>
           </codify:find-replace>

--- a/dc/council/periods/21/laws/21-208.xml
+++ b/dc/council/periods/21/laws/21-208.xml
@@ -161,10 +161,10 @@
             </codify:find-replace>
           </para>
           <para>
-            <codify:repeal path="(E)"/>
-            <codify:repeal codify:doc="D.C. Code" path="§1-1001.07|(c)|(1)|(F)"/>
             <num>(iii)</num>
             <text>Subparagraphs (E) and (F) are repealed.</text>
+            <codify:repeal path="(E)"/>
+            <codify:repeal path="(F)"/>
           </para>
           <para codify:path="(I)">
             <num>(iv)</num>

--- a/dc/council/periods/21/laws/21-252.xml
+++ b/dc/council/periods/21/laws/21-252.xml
@@ -39,9 +39,9 @@
         <aftertext>.</aftertext>
       </para>
       <para codify:path="(5)">
-        <codify:repeal/>
         <num>(2)</num>
         <text>Paragraph (5) is repealed.</text>
+        <codify:repeal/>
       </para>
       <para codify:path="(6)">
         <num>(3)</num>

--- a/dc/council/periods/21/laws/21-254.xml
+++ b/dc/council/periods/21/laws/21-254.xml
@@ -225,7 +225,7 @@
         <text>New sections 108a through 108g are added to read as follows:</text>
         <include>
           <section>
-            <codify:insert codify:doc="D.C. Code" codify:path="|8|1A|I" after="§8-151.08" num-value="8-151.08a" history-prefix="as added"/>
+            <codify:insert doc="D.C. Code" path="|8|1A|I" after="§8-151.08" num-value="8-151.08a" history-prefix="as added"/>
             <num>108a</num>
             <heading>State safety oversight agency designation for DC Streetcar.</heading>
             <text>DDOE is designated as the state safety oversight agency, as described in 49 U.S.C. § 5329(e) and regulations issued thereunder, for the DC Streetcar when:</text>
@@ -252,7 +252,7 @@
             <annotation doc="D.C. Law 16-51" type="History" path="§108a">Feb. 15, 2006, D.C. Law 16-51, § 108a</annotation>
           </section>
           <section>
-            <codify:insert codify:doc="D.C. Code" codify:path="|8|1A|I" after="§8-151.08a" num-value="8-151.08b" history-prefix="as added"/>
+            <codify:insert doc="D.C. Code" path="|8|1A|I" after="§8-151.08a" num-value="8-151.08b" history-prefix="as added"/>
             <num>108b</num>
             <heading>Duties, powers, and requirements related to DC Streetcar safety oversight.</heading>
             <para>
@@ -325,7 +325,7 @@
             <codify:not-funded-anno doc="D.C. Code" path="§8-151.08b" applicability-path="§501" action="creation of"/>
           </section>
           <section>
-            <codify:insert codify:doc="D.C. Code" codify:path="|8|1A|I" after="§8-151.08b" num-value="8-151.08c" history-prefix="as added"/>
+            <codify:insert doc="D.C. Code" path="|8|1A|I" after="§8-151.08b" num-value="8-151.08c" history-prefix="as added"/>
             <num>108c</num>
             <heading>Railroad safety and security authority.</heading>
             <para>
@@ -347,7 +347,7 @@
             <codify:not-funded-anno doc="D.C. Code" path="§8-151.08c" applicability-path="§501" action="creation of"/>
           </section>
           <section>
-            <codify:insert codify:doc="D.C. Code" codify:path="|8|1A|I" after="§8-151.08c" num-value="8-151.08d" history-prefix="as added"/>
+            <codify:insert doc="D.C. Code" path="|8|1A|I" after="§8-151.08c" num-value="8-151.08d" history-prefix="as added"/>
             <num>108d</num>
             <heading>Emergency response.</heading>
             <text>The Director may take any action necessary to address emergency response planning and operations related to rail systems in the District including:</text>
@@ -366,7 +366,7 @@
             <codify:not-funded-anno doc="D.C. Code" path="§8-151.08d" applicability-path="§501" action="creation of"/>
           </section>
           <section>
-            <codify:insert codify:doc="D.C. Code" codify:path="|8|1A|I" after="§8-151.08d" num-value="8-151.08e" history-prefix="as added"/>
+            <codify:insert doc="D.C. Code" path="|8|1A|I" after="§8-151.08d" num-value="8-151.08e" history-prefix="as added"/>
             <num>108e</num>
             <heading>Public reporting.</heading>
             <para>
@@ -392,7 +392,7 @@
             <codify:not-funded-anno doc="D.C. Code" path="§8-151.08e" applicability-path="§501" action="creation of"/>
           </section>
           <section>
-            <codify:insert codify:doc="D.C. Code" codify:path="|8|1A|I" after="§8-151.08e" num-value="8-151.08f" history-prefix="as added"/>
+            <codify:insert doc="D.C. Code" path="|8|1A|I" after="§8-151.08e" num-value="8-151.08f" history-prefix="as added"/>
             <num>108f</num>
             <heading>Entry and inspection.</heading>
             <text>The Director shall have the authority to inspect railroad equipment, facilities, rolling stock, or operations or to inspect any record related to the safety, security, and operations of the railroad at any reasonable time and upon the presentation of appropriate credentials to the owner, operator, or person in charge, to the extent permissible under federal railroad safety laws.</text>
@@ -403,7 +403,7 @@
             <codify:not-funded-anno doc="D.C. Code" path="§8-151.08f" applicability-path="§501" action="creation of"/>
           </section>
           <section>
-            <codify:insert codify:doc="D.C. Code" codify:path="|8|1A|I" after="§8-151.08f" num-value="8-151.08g" history-prefix="as added"/>
+            <codify:insert doc="D.C. Code" path="|8|1A|I" after="§8-151.08f" num-value="8-151.08g" history-prefix="as added"/>
             <num>108g</num>
             <heading>Study of fees.</heading>
             <text>By November 30, 2017, the Mayor shall transmit to the Chairperson of the Council committee with oversight of transportation a report and recommendation as to the imposition of fees related to the transportation of hazardous materials under 49 U.S.C. § 5125(f).</text>

--- a/dc/council/periods/21/laws/21-255.xml
+++ b/dc/council/periods/21/laws/21-255.xml
@@ -156,28 +156,28 @@
     <para>
       <num>(d)</num>
       <text>Section 16-402 is repealed.</text>
-      <codify:repeal codify:doc="D.C. Code" codify:path="§16-402"/>
+      <codify:repeal doc="D.C. Code" path="§16-402"/>
     </para>
     <para>
       <num>(e)</num>
       <text>New sections 16-403 through 16-412 are added to read as follows:</text>
       <include>
         <section>
-          <codify:insert codify:doc="D.C. Code" codify:path="|16|4" after="§16-402"/>
+          <codify:insert doc="D.C. Code" path="|16|4" after="§16-402"/>
           <prefix>§</prefix>
           <num>16-403</num>
           <heading>Collaborative reproduction authorized.</heading>
           <text>An intended parent or parents shall be recognized as the parent or parents of a child; provided, that the surrogate and the intended parent or parents comply with the requirements of this chapter.</text>
         </section>
         <section>
-          <codify:insert codify:doc="D.C. Code" codify:path="|16|4" after="§16-403"/>
+          <codify:insert doc="D.C. Code" path="|16|4" after="§16-403"/>
           <prefix>§</prefix>
           <num>16-404</num>
           <heading>Surrogacy agreements authorized.</heading>
           <text>A surrogacy agreement shall be enforceable; provided, that all parties to the agreement and the agreement itself meet the requirements of <code-cite doc="D.C. Code" path="§16-405">§ 16-405</code-cite> and <code-cite doc="D.C. Code" path="§16-406">§ 16-406</code-cite>.</text>
         </section>
         <section>
-          <codify:insert codify:doc="D.C. Code" codify:path="|16|4" after="§16-404"/>
+          <codify:insert doc="D.C. Code" path="|16|4" after="§16-404"/>
           <prefix>§</prefix>
           <num>16-405</num>
           <heading>Requirements of surrogates and intended parents.</heading>
@@ -226,7 +226,7 @@
           </para>
         </section>
         <section>
-          <codify:insert codify:doc="D.C. Code" codify:path="|16|4" after="§16-405"/>
+          <codify:insert doc="D.C. Code" path="|16|4" after="§16-405"/>
           <prefix>§</prefix>
           <num>16-406</num>
           <heading>Contents of surrogacy agreements.</heading>
@@ -332,7 +332,7 @@
           </para>
         </section>
         <section>
-          <codify:insert codify:doc="D.C. Code" codify:path="|16|4" after="§16-406"/>
+          <codify:insert doc="D.C. Code" path="|16|4" after="§16-406"/>
           <prefix>§</prefix>
           <num>16-407</num>
           <heading>Parentage in collaborative reproduction.</heading>
@@ -376,7 +376,7 @@
           </para>
         </section>
         <section>
-          <codify:insert codify:doc="D.C. Code" codify:path="|16|4" after="§16-407"/>
+          <codify:insert doc="D.C. Code" path="|16|4" after="§16-407"/>
           <prefix>§</prefix>
           <num>16-408</num>
           <heading>Court order of parentage.</heading>
@@ -483,21 +483,21 @@
           </para>
         </section>
         <section>
-          <codify:insert codify:doc="D.C. Code" codify:path="|16|4" after="§16-408"/>
+          <codify:insert doc="D.C. Code" path="|16|4" after="§16-408"/>
           <prefix>§</prefix>
           <num>16-409</num>
           <heading>Effect of subsequent marriage or domestic partnership or dissolution of marriage or domestic partnership.</heading>
           <text>A subsequent marriage or domestic partnership or dissolution thereof for either the surrogate or the intended parent or parents shall have no bearing on the validity of the surrogacy agreement or the child's parentage.</text>
         </section>
         <section>
-          <codify:insert codify:doc="D.C. Code" codify:path="|16|4" after="§16-409"/>
+          <codify:insert doc="D.C. Code" path="|16|4" after="§16-409"/>
           <prefix>§</prefix>
           <num>16-410</num>
           <heading>Effect of death of intended parent.</heading>
           <text>If an intended parent dies after a successful insemination or embryo transfer, the surviving spouse or domestic partner shall assume all obligations with respect to the surrogacy agreement, and both will be considered the parents of the child.</text>
         </section>
         <section>
-          <codify:insert codify:doc="D.C. Code" codify:path="|16|4" after="§16-410"/>
+          <codify:insert doc="D.C. Code" path="|16|4" after="§16-410"/>
           <prefix>§</prefix>
           <num>16-411</num>
           <heading>Effect of withdrawal of consent.</heading>
@@ -528,7 +528,7 @@
           </para>
         </section>
         <section>
-          <codify:insert codify:doc="D.C. Code" codify:path="|16|4" after="§16-411"/>
+          <codify:insert doc="D.C. Code" path="|16|4" after="§16-411"/>
           <prefix>§</prefix>
           <num>16-412</num>
           <heading>Rules.</heading>

--- a/dc/council/periods/22/laws/22-24.xml
+++ b/dc/council/periods/22/laws/22-24.xml
@@ -197,7 +197,7 @@
   <section>
     <num>5</num>
     <text>Section 47-902(23) of the District of Columbia Official Code is amended by striking the phrase "low- and moderate-income household" and inserting the phrase "eligible household" in its place.</text>
-    <codify:find-replace doc="D.C. Code" path="§47-902|(23)" count="1" tech="true">
+    <codify:find-replace doc="D.C. Code" path="§47-902|(23)" count="1" technical="true">
       <find>low- or moderate-income household</find>
       <replace>eligible household</replace>
     </codify:find-replace>

--- a/dc/council/periods/22/laws/22-33.xml
+++ b/dc/council/periods/22/laws/22-33.xml
@@ -1563,8 +1563,7 @@
         <num>2023</num>
         <heading>Applicability.</heading>
         <text>Section 2022(b) shall apply as of May 30, 2017.</text>
-        <codify:annotation doc="D.C. Code" path="§42-2802" type="Applicability" history="false">
-            <cite doc="D.C. Law 22-33" path="§2023">Section 2023 of D.C. Law 22-33</cite> provided that subsection (e) of this section shall apply as of May 30, 2017.
+        <codify:annotation doc="D.C. Code" path="§42-2802" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§2023">Section 2023 of D.C. Law 22-33</cite> provided that subsection (e) of this section shall apply as of May 30, 2017.
           </codify:annotation>
       </section>
     </container>
@@ -1803,8 +1802,7 @@
           <para>
             <num>(2)</num>
             <text>Sub-subparagraph (iv) is amended by striking the phrase "at no less than" and inserting the phrase "at an hourly rate equal to" in its place.</text>
-            <codify:annotation doc="D.C. Code" path="§32-241" type="Editor's Notes" history="false">
-              <cite doc="D.C. Law 22-33" path="§2062|(a)|(2)">Section 2062(a)(2) of D.C. Law 22-33</cite> amended subsection (a)(1)(iv) of this subsection which is an unfunded provision and does not appear in this codification. 
+            <codify:annotation doc="D.C. Code" path="§32-241" type="Editor's Notes" history="false"><cite doc="D.C. Law 22-33" path="§2062|(a)|(2)">Section 2062(a)(2) of D.C. Law 22-33</cite> amended subsection (a)(1)(iv) of this subsection which is an unfunded provision and does not appear in this codification. 
             </codify:annotation>
           </para>
         </para>
@@ -2385,7 +2383,6 @@
         <text>This subtitle may be cited as the "Historic Preservation of Derelict District Properties Amendment Act of 2017".</text>
       </section>
       <section>
-      <!-- codified as note. not necessry to translate sections -->
         <num>2192</num>
         <text>Section 2 of the Historic Preservation of Derelict District Properties Act of 2016, effective March 11, 2017 (D.C. Law 21-223; 64 DCR 182), is amended by adding new subsections (c-1) and (c-2) to read as follows:</text>
         <include>
@@ -2649,7 +2646,6 @@
         <text>This subtitle may be cited as the "Purchase Card Program Budgeting Act of 2017".</text>
       </section>
       <section>
-        <!--  This is codfied as a note -->
         <num>2232</num>
         <text>Beginning in Fiscal Year 2018, the Chief Financial Officer shall assign an individual agency-level code for transactions made pursuant to the Purchase Card Program, as defined in section 104(51) of the Procurement Practices Reform Act of 2010, effective April 8, 2011 (D.C. Law 18-371; D.C. Official Code § 2-351.04(51)), in the District's financial system. The agency-level code shall be used to track the operating budget for the District's Purchase Card Program and any funds that are appropriated for that purpose.</text>
         <codify:annotation doc="D.C. Code" path="§2-361.03" type="Editor's Notes" history="false">
@@ -2735,8 +2731,7 @@
           </para>
         </include>
         <aftertext>.</aftertext>
-        <codify:annotation doc="D.C. Code" path="§2-1402.11" type="Editor's Notes" history="false">
-          <cite doc="D.C. Law 22-33" path="§2252">Section 2252 of D.C. Law 22-33</cite> amended a provision of this section that is not funded.  Therefore that amendment has not been given effect.
+        <codify:annotation doc="D.C. Code" path="§2-1402.11" type="Editor's Notes" history="false"><cite doc="D.C. Law 22-33" path="§2252">Section 2252 of D.C. Law 22-33</cite> amended a provision of this section that is not funded.  Therefore that amendment has not been given effect.
         </codify:annotation>
       </section>
     </container>
@@ -3174,8 +3169,7 @@
           </include>
           <aftertext>.</aftertext>
         </para>
-        <codify:annotation codify:doc="D.C. Code" path="§31-2802" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§3024">Section 3024 of D.C. Law 22-33</cite> provided that the amendments made to this section by <cite doc="D.C. Law 22-33" path="§3022">section 3022 of D.C. Law 22-33</cite> shall apply to all health benefit plans issued or renewed in the District 90 or more days after December 13, 2017.
+        <codify:annotation codify:doc="D.C. Code" path="§31-2802" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§3024">Section 3024 of D.C. Law 22-33</cite> provided that the amendments made to this section by <cite doc="D.C. Law 22-33" path="§3022">section 3022 of D.C. Law 22-33</cite> shall apply to all health benefit plans issued or renewed in the District 90 or more days after December 13, 2017.
         </codify:annotation>
       </section>
       <section codify:path="§5-416">
@@ -3183,8 +3177,7 @@
         <text>Section 502 of the Revenue Act of 1978, effective April 19, 1977 (D.C. Law 1-124; D.C. Official Code § 5-416), is amended by adding a new subsection (c) to read as follows:</text>
         <include>
           <para>
-            <codify:repeal doc="D.C. Law 21-125" path="§901" history="false"/>
-            <codify:insert/>
+            <codify:insert doc="D.C. Law 1-124" path="§502"/>
             <num>(c)</num>
             <para>
               <num>(1)</num>
@@ -3220,8 +3213,7 @@
           </para>
         </include>
         <aftertext>.</aftertext>
-        <codify:annotation codify:doc="D.C. Code" path="§5-416" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§3024">Section 3024 of D.C. Law 22-33</cite> provided that the amendments made to this section by <cite doc="D.C. Law 22-33" path="§3023">section 3023 of D.C. Law 22-33</cite> shall apply to all health benefit plans issued or renewed in the District 90 or more days after December 13, 2017.
+        <codify:annotation codify:doc="D.C. Code" path="§5-416" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§3024">Section 3024 of D.C. Law 22-33</cite> provided that the amendments made to this section by <cite doc="D.C. Law 22-33" path="§3023">section 3023 of D.C. Law 22-33</cite> shall apply to all health benefit plans issued or renewed in the District 90 or more days after December 13, 2017.
         </codify:annotation>
       </section>
       <section>
@@ -3322,8 +3314,7 @@
                 <num>(f)</num>
                 <text>The ONSE shall have grant-making authority for the purpose of providing funds that seek to reduce and prevent violent crime. Grants made pursuant to this subsection shall be administered pursuant to the requirements set forth in <code-cite doc="D.C. Code" path="1|3|XII-A|B">the Grant Administration Act of 2013, effective December 24, 2013 (D.C. Law 20-61; D.C. Official Code § 1-328.11 <em>et seq</em>.)</code-cite>.</text>
               </para>
-              <codify:annotation doc="D.C. Code" path="§7-2411" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§7014">Section 7014 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-125" path="§901">§ 901 of D.C. Law 21-125</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-125">D.C. Law 21-125</cite> have been given effect.
+              <codify:annotation doc="D.C. Code" path="§7-2411" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7014">Section 7014 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-125" path="§901">§ 901 of D.C. Law 21-125</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-125">D.C. Law 21-125</cite> have been given effect.
           </codify:annotation>
             </section>
           </include>
@@ -3367,8 +3358,7 @@
                   <num>(2)</num>
                   <text>The Executive Director shall regularly conduct assessments and evaluations, to be performed by a qualified research entity, of outcomes for participants in ONSE programs.</text>
                 </para>
-                <codify:annotation doc="D.C. Code" path="§7-2412" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§7014">Section 7014 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-125" path="§901">§ 901 of D.C. Law 21-125</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-125">D.C. Law 21-125</cite> have been given effect.
+                <codify:annotation doc="D.C. Code" path="§7-2412" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7014">Section 7014 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-125" path="§901">§ 901 of D.C. Law 21-125</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-125">D.C. Law 21-125</cite> have been given effect.
           </codify:annotation>
               </para>
             </section>
@@ -3423,8 +3413,7 @@
                   <num>(3)</num>
                   <text>Appropriate overhead or administrative expenses related to the ONSE and the Fund.</text>
                 </para>
-                <codify:annotation doc="D.C. Code" path="§7-2413" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§7014">Section 7014 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-125" path="§901">§ 901 of D.C. Law 21-125</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-125">D.C. Law 21-125</cite> have been given effect.
+                <codify:annotation doc="D.C. Code" path="§7-2413" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7014">Section 7014 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-125" path="§901">§ 901 of D.C. Law 21-125</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-125">D.C. Law 21-125</cite> have been given effect.
           </codify:annotation>
               </para>
             </include>
@@ -4153,8 +4142,7 @@
         <num>3113</num>
         <heading>Applicability.</heading>
         <text>This subtitle shall apply as of the effective date of the Fiscal Year 2018 Budget Support Emergency Act of 2017, passed on emergency basis on June 27, 2017 (Enrolled version of Bill 22-341).</text>
-        <codify:annotation doc="D.C. Code" path="§5-404.01" type="Editor's Notes" history="false">
-       <cite doc="D.C. Law 22-33" path="§3113"> Section 3113 of D.C. Law 22-33</cite> provided that the addition of subsection (c-1) to this section shall apply as of June 27, 2017.
+        <codify:annotation doc="D.C. Code" path="§5-404.01" type="Editor's Notes" history="false"><cite doc="D.C. Law 22-33" path="§3113"> Section 3113 of D.C. Law 22-33</cite> provided that the addition of subsection (c-1) to this section shall apply as of June 27, 2017.
         </codify:annotation>
       </section>
     </container>
@@ -4537,7 +4525,6 @@
         </para>
       </section>
       <section>
-        <!--  This is a note. No translations necessary. -->
         <num>4003</num>
         <para>
           <num>(a)</num>
@@ -5114,7 +5101,7 @@
           </para>
           <para>
             <num>(5)</num>
-            <text>"Subsidized child care" means part-time or full-time child care services, subsidized in whole or in part to eligible families pursuant to local and federal law, including <span codify:value="§§"></span> <code-cite doc="D.C. Code" path="§4-404.01" codify:value="4-404.01">sections 5a and 6 of the Day Care Policy Amendment Act of 1998, effective April 13, 1999 (D.C. Law 12-216; D.C. Official Code §§ 4-404.01</code-cite> and <code-cite doc="D.C. Code" path="§4-405" codify:value="4-405">4-405)</code-cite>, and the Child Care and Development Block Grant Act of 2014, approved November 19, 2014 (128 Stat. 1971; 42 U.S.C. § 9858, note).</text>
+            <text>"Subsidized child care" means part-time or full-time child care services, subsidized in whole or in part to eligible families pursuant to local and federal law, including <span codify:value="§§"/> <code-cite doc="D.C. Code" path="§4-404.01" codify:value="4-404.01">sections 5a and 6 of the Day Care Policy Amendment Act of 1998, effective April 13, 1999 (D.C. Law 12-216; D.C. Official Code §§ 4-404.01</code-cite> and <code-cite doc="D.C. Code" path="§4-405" codify:value="4-405">4-405)</code-cite>, and the Child Care and Development Block Grant Act of 2014, approved November 19, 2014 (128 Stat. 1971; 42 U.S.C. § 9858, note).</text>
           </para>
           <para>
             <num>(6)</num>
@@ -5267,7 +5254,6 @@
         <text>Section 5 of the Child Care Study Act of 2017, enacted on June 5, 2017 (D.C. Act 22-72; 64 DCR 5610), is amended to read as follows:</text>
         <include>
           <section>
-            <!-- <codify:replace path="§7-2011.04"/> Add after this law becomes effective (this is part of Law 22-11)-->
             <codify:replace doc="D.C. Code" path="§7-2011.04"/>
             <num codify:value="7-2011.04">5</num>
             <heading>Submission of studies to the Council.</heading>
@@ -5306,8 +5292,7 @@
         <num>4113</num>
         <heading>Applicability.</heading>
         <text>This subtitle shall apply as of September 30, 2017.</text>
-        <codify:annotation doc="D.C. Code" path="§5-404.01" type="Editor's Notes" history="false">
-        <cite doc="D.C. Law 22-33" path="§4113">Section 4113 of D.C. Law 22-33</cite> provided that the addition of subsection (c-1) to this section shall apply as of September 30, 2017.
+        <codify:annotation doc="D.C. Code" path="§5-404.01" type="Editor's Notes" history="false"><cite doc="D.C. Law 22-33" path="§4113">Section 4113 of D.C. Law 22-33</cite> provided that the addition of subsection (c-1) to this section shall apply as of September 30, 2017.
         </codify:annotation>
       </section>
     </container>
@@ -5388,8 +5373,7 @@
         <num>4142</num>
         <text>Section 10(e) of the Day Care Policy Act of 1979, effective September 19, 1979 (D.C. Law 3-16; D.C. Official Code § 4-409(e)), is repealed.</text>
         <codify:repeal/>
-        <codify:annotation doc="D.C. Code" path="§4-409" type="Applicability" history="false">
-        <cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
+        <codify:annotation doc="D.C. Code" path="§4-409" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
         </codify:annotation>
       </section>
       <section codify:path="§38-203|(k)">
@@ -5399,8 +5383,7 @@
           <find>October 1</find>
           <replace>November 30</replace>
         </codify:find-replace>
-        <codify:annotation doc="D.C. Code" path="§38-203" type="Applicability" history="false">
-        <cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
+        <codify:annotation doc="D.C. Code" path="§38-203" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
         </codify:annotation>
       </section>
       <section codify:path="§38-236|(d)">
@@ -5410,8 +5393,7 @@
           <find>October 1</find>
           <replace>December 15</replace>
         </codify:find-replace>
-        <codify:annotation doc="D.C. Code" path="§38-236" type="Applicability" history="false">
-        <cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
+        <codify:annotation doc="D.C. Code" path="§38-236" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
         </codify:annotation>
       </section>
       <section>
@@ -5424,8 +5406,7 @@
             <find>September 15</find>
             <replace>December 30</replace>
           </codify:find-replace>
-          <codify:annotation doc="D.C. Code" path="§38-271.03" type="Applicability" history="false">
-        <cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
+          <codify:annotation doc="D.C. Code" path="§38-271.03" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
         </codify:annotation>
         </para>
         <para codify:path="§38-271.04">
@@ -5435,8 +5416,7 @@
             <find>September 30</find>
             <replace>December 30</replace>
           </codify:find-replace>
-          <codify:annotation doc="D.C. Code" path="§38-271.04" type="Applicability" history="false">
-        <cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
+          <codify:annotation doc="D.C. Code" path="§38-271.04" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
         </codify:annotation>
         </para>
         <para codify:path="§38-271.05|(a)">
@@ -5446,8 +5426,7 @@
             <find>September 30</find>
             <replace>December 30</replace>
           </codify:find-replace>
-          <codify:annotation doc="D.C. Code" path="§38-271.05" type="Applicability" history="false">
-        <cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
+          <codify:annotation doc="D.C. Code" path="§38-271.05" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
         </codify:annotation>
         </para>
       </section>
@@ -5458,8 +5437,7 @@
           <find>May 9</find>
           <replace>July 31</replace>
         </codify:find-replace>
-        <codify:annotation doc="D.C. Code" path="§38-312.03" type="Applicability" history="false">
-        <cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
+        <codify:annotation doc="D.C. Code" path="§38-312.03" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
         </codify:annotation>
       </section>
       <section codify:path="§38-823.03">
@@ -5469,8 +5447,7 @@
           <find>June 30</find>
           <replace>September 30</replace>
         </codify:find-replace>
-        <codify:annotation doc="D.C. Code" path="§38-823.03" type="Applicability" history="false">
-        <cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
+        <codify:annotation doc="D.C. Code" path="§38-823.03" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
         </codify:annotation>
       </section>
       <section codify:path="§38-2561.16|(a)">
@@ -5480,8 +5457,7 @@
           <find>to the Council</find>
           <replace/>
         </codify:find-replace>
-        <codify:annotation doc="D.C. Code" path="§38-2561.16" type="Applicability" history="false">
-        <cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
+        <codify:annotation doc="D.C. Code" path="§38-2561.16" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
         </codify:annotation>
       </section>
       <section codify:path="§38-2911|(a)|(2)">
@@ -5491,14 +5467,12 @@
           <find>2016</find>
           <replace>2017</replace>
         </codify:find-replace>
-        <codify:annotation doc="D.C. Code" path="§38-2911" type="Applicability" history="false">
-        <cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
+        <codify:annotation doc="D.C. Code" path="§38-2911" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§4150">Section 4150 of D.C. Law 22-33</cite> provided that the amendment made to this section shall apply as of June 27, 2017.
         </codify:annotation>
       </section>
       <section>
         <num>4150</num>
         <heading>Applicability.</heading>
-        <!-- This is a note -->
         <text>This subtitle shall apply as of the effective date of the Fiscal Year 2018 Budget Support Emergency Act of 2017, passed on emergency basis on June 27, 2017 (Enrolled version of Bill 22-341).</text>
       </section>
     </container>
@@ -7103,8 +7077,7 @@
         <num>6053</num>
         <heading>Applicability.</heading>
         <text>This subtitle shall apply as of September 30, 2017.</text>
-        <codify:annotation doc="D.C. Code" path="§8-103.09d" type="Editor's Notes" history="false">
-          <cite doc="D.C. Law 22-33" path="§6063">Section 6063 of D.C. Law 22-33</cite> provided that this section shall apply as of September 30, 2017.
+        <codify:annotation doc="D.C. Code" path="§8-103.09d" type="Editor's Notes" history="false"><cite doc="D.C. Law 22-33" path="§6063">Section 6063 of D.C. Law 22-33</cite> provided that this section shall apply as of September 30, 2017.
         </codify:annotation>
       </section>
     </container>
@@ -7431,26 +7404,59 @@
           </para>
         </include>
         <aftertext>.</aftertext>
-        <codify:annotation doc="D.C. Code" path="§8-651.02" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§6122">Section 6122 of D.C. Law 22-33</cite> provided amended <cite doc="D.C. Law 21-133" path="§4|(a)">section 4(a) of D.C. Law 21-133</cite> to read as follows:
+        <codify:annotation doc="D.C. Code" path="§8-651.02" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§6122">Section 6122 of D.C. Law 22-33</cite> provided amended <cite doc="D.C. Law 21-133" path="§4|(a)">section 4(a) of D.C. Law 21-133</cite> to read as follows:
         </codify:annotation>
         <codify:annotation doc="D.C. Code" path="§8-651.02" type="Applicability" history="false">
-          <include><para><num>(a)</num><text>Section 2(b)(1) and (c) shall not apply to:</text><para><num>(1)</num><text>A tree with a circumference of 55 inches or more for which a person or nongovernmental entity has an application for a tree removal permit, which is subsequently approved, pending as of the effective date of this act; or</text></para><para><num>(2)</num><text>A tree with a circumference of 100 inches or more that is located on residential property for which a District resident has a building permit application, which is subsequently approved, for a single-family home that contemplates removal of the tree pending as of October 1, 2016.</text></para></para></include>
+          <include>
+            <para>
+              <num>(a)</num>
+              <text>Section 2(b)(1) and (c) shall not apply to:</text>
+              <para>
+                <num>(1)</num>
+                <text>A tree with a circumference of 55 inches or more for which a person or nongovernmental entity has an application for a tree removal permit, which is subsequently approved, pending as of the effective date of this act; or</text>
+              </para>
+              <para>
+                <num>(2)</num>
+                <text>A tree with a circumference of 100 inches or more that is located on residential property for which a District resident has a building permit application, which is subsequently approved, for a single-family home that contemplates removal of the tree pending as of October 1, 2016.</text>
+              </para>
+            </para>
+          </include>
+        </codify:annotation>
+        <codify:annotation doc="D.C. Code" path="§8-651.04" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§6122">Section 6122 of D.C. Law 22-33</cite> provided amended <cite doc="D.C. Law 21-133" path="§4|(a)">section 4(a) of D.C. Law 21-133</cite> to read as follows:
         </codify:annotation>
         <codify:annotation doc="D.C. Code" path="§8-651.04" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§6122">Section 6122 of D.C. Law 22-33</cite> provided amended <cite doc="D.C. Law 21-133" path="§4|(a)">section 4(a) of D.C. Law 21-133</cite> to read as follows:
+          <include>
+            <para>
+              <num>(a)</num>
+              <text>Section 2(b)(1) and (c) shall not apply to:</text>
+              <para>
+                <num>(1)</num>
+                <text>A tree with a circumference of 55 inches or more for which a person or nongovernmental entity has an application for a tree removal permit, which is subsequently approved, pending as of the effective date of this act; or</text>
+              </para>
+              <para>
+                <num>(2)</num>
+                <text>A tree with a circumference of 100 inches or more that is located on residential property for which a District resident has a building permit application, which is subsequently approved, for a single-family home that contemplates removal of the tree pending as of October 1, 2016.</text>
+              </para>
+            </para>
+          </include>
         </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§8-651.04" type="Applicability" history="false">
-         
-          <include><para><num>(a)</num><text>Section 2(b)(1) and (c) shall not apply to:</text><para><num>(1)</num><text>A tree with a circumference of 55 inches or more for which a person or nongovernmental entity has an application for a tree removal permit, which is subsequently approved, pending as of the effective date of this act; or</text></para><para><num>(2)</num><text>A tree with a circumference of 100 inches or more that is located on residential property for which a District resident has a building permit application, which is subsequently approved, for a single-family home that contemplates removal of the tree pending as of October 1, 2016.</text></para></para></include>
+        <codify:annotation doc="D.C. Code" path="§8-651.04a" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§6122">Section 6122 of D.C. Law 22-33</cite> provided amended <cite doc="D.C. Law 21-133" path="§4|(a)">section 4(a) of D.C. Law 21-133</cite> to read as follows:
         </codify:annotation>
-                <codify:annotation doc="D.C. Code" path="§8-651.04a" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§6122">Section 6122 of D.C. Law 22-33</cite> provided amended <cite doc="D.C. Law 21-133" path="§4|(a)">section 4(a) of D.C. Law 21-133</cite> to read as follows:
-        </codify:annotation>
-
         <codify:annotation doc="D.C. Code" path="§8-651.04a" type="Applicability" history="false">
-         
-          <include><para><num>(a)</num><text>Section 2(b)(1) and (c) shall not apply to:</text><para><num>(1)</num><text>A tree with a circumference of 55 inches or more for which a person or nongovernmental entity has an application for a tree removal permit, which is subsequently approved, pending as of the effective date of this act; or</text></para><para><num>(2)</num><text>A tree with a circumference of 100 inches or more that is located on residential property for which a District resident has a building permit application, which is subsequently approved, for a single-family home that contemplates removal of the tree pending as of October 1, 2016.</text></para></para></include>
+          <include>
+            <para>
+              <num>(a)</num>
+              <text>Section 2(b)(1) and (c) shall not apply to:</text>
+              <para>
+                <num>(1)</num>
+                <text>A tree with a circumference of 55 inches or more for which a person or nongovernmental entity has an application for a tree removal permit, which is subsequently approved, pending as of the effective date of this act; or</text>
+              </para>
+              <para>
+                <num>(2)</num>
+                <text>A tree with a circumference of 100 inches or more that is located on residential property for which a District resident has a building permit application, which is subsequently approved, for a single-family home that contemplates removal of the tree pending as of October 1, 2016.</text>
+              </para>
+            </para>
+          </include>
         </codify:annotation>
       </section>
     </container>
@@ -7779,8 +7785,7 @@
               <num>(e)</num>
               <text>Repealed.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§22-1841" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7003">Section 7003 of D.C. Law 22-33</cite> repealed subsection (e) of this section that had provided that this section shall apply upon the inclusion of its fiscal effect in an approved budget and financial plan. Therefore the addition of this section by D.C. Law 18-239 has been given effect.
+            <codify:annotation doc="D.C. Code" path="§22-1841" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7003">Section 7003 of D.C. Law 22-33</cite> repealed subsection (e) of this section that had provided that this section shall apply upon the inclusion of its fiscal effect in an approved budget and financial plan. Therefore the addition of this section by D.C. Law 18-239 has been given effect.
             </codify:annotation>
           </section>
         </include>
@@ -7863,8 +7868,7 @@
       <section>
         <num>7009</num>
         <text>Section 12(b) of the Public Space Enforcement Amendment Act of 2014, effective March 11, 2015 (D.C. Law 20-207; 61 DCR 12690), is repealed.</text>
-        <codify:annotation doc="D.C. Code" path="§50-921.04" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§7009">Section 7009 of D.C. Law 22-33</cite> removed the applicability restriction of § 12(b) of D.C. Law 20-207 which had already been overwritten by D.C. Law 21-124
+        <codify:annotation doc="D.C. Code" path="§50-921.04" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7009">Section 7009 of D.C. Law 22-33</cite> removed the applicability restriction of § 12(b) of D.C. Law 20-207 which had already been overwritten by D.C. Law 21-124
         </codify:annotation>
       </section>
       <section>
@@ -7908,7 +7912,6 @@
       <section>
         <num>7013</num>
         <text>Section 4 of the Youth Suicide Prevention and School Climate Survey Amendment Act of 2016, effective June 17, 2016 (D.C. Law 21-120; 63 DCR 6856), is repealed.</text>
-        <!--  The execution of this repeal takes place inside Law 21-120 because the non-funded provision is amended earlier in this act at section 4052 -->
         <codify:annotation doc="D.C. Code" path="§7-1131.17" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7013">Section 7013 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-120" path="§4">§ 4 of D.C. Law 21-120</cite>. Therefore the amendment of this section by <cite doc="D.C. Law 21-120">D.C. Law 21-120</cite> has been given effect.</codify:annotation>
         <codify:annotation doc="D.C. Code" path="§38-2602" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7013">Section 7013 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-120" path="§4">§ 4 of D.C. Law 21-120</cite>. Therefore the amendment of this section by <cite doc="D.C. Law 21-120">D.C. Law 21-120</cite> has been given effect.</codify:annotation>
       </section>
@@ -7939,7 +7942,6 @@
         <text>Section 18 of the Building Service Employees Minimum Work Week Act of 2016, effective October 8, 2016 (D.C. Law 21-157; D.C. Official Code § 32-1051.17), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-157" path="§18"/>
         <codify:annotation doc="D.C. Code" path="32|10A" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7016">Section 7016 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-157" path="§18">§ 18 of D.C. Law 21-157</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-157">D.C. Law 21-157</cite> have been given effect.</codify:annotation>
-        
       </section>
       <section>
         <num>7017</num>
@@ -7953,8 +7955,7 @@
         </codify:replace>
         <codify:annotation doc="D.C. Code" path="§2-352.05" history="false" type="Applicability"><cite doc="D.C. Law 22-33" path="§7017">Section 7017 of Law 22-33</cite> amended <cite doc="D.C. Law 21-158" path="§5">section 5 of D.C. Law 21-158</cite>, retaining the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-158"> D.C. Law 21-158</cite> have not been implemented. 
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§2-352.07" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7017">Section 7017 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-158" path="§5">§ 5 of D.C. Law 21-158</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-158">D.C. Law 21-158</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§2-352.07" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7017">Section 7017 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-158" path="§5">§ 5 of D.C. Law 21-158</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-158">D.C. Law 21-158</cite> have been given effect.
             </codify:annotation>
         <codify:replace doc="D.C. Code" path="§2-356.06" history="false">
           <section>
@@ -7972,8 +7973,7 @@
         <para>
           <num>(a)</num>
           <text>Section 18 of the Death with Dignity Act of 2016, effective February 18, 2017 (D.C. Law 21-182; D.C. Official Code § 7-661.17), is repealed.</text>
-          <codify:annotation doc="D.C. Code" path="7|6B" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7018">Section 7018 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-182" path="§18">§ 18 of D.C. Law 21-182</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-182">D.C. Law 21-182</cite> has been given effect.
+          <codify:annotation doc="D.C. Code" path="7|6B" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7018">Section 7018 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-182" path="§18">§ 18 of D.C. Law 21-182</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-182">D.C. Law 21-182</cite> has been given effect.
             </codify:annotation>
           <codify:repeal doc="D.C. Law 21-182" path="§18"/>
           <codify:repeal doc="D.C. Code" path="§7-661.17"/>
@@ -7987,98 +7987,77 @@
         <num>7019</num>
         <text>Section 4 of the Charitable Solicitations Relief Amendment Act of 2016, effective February 18, 2017 (D.C. Law 21-202; 63 DCR 15043), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-202" path="§4"/>
-        <codify:annotation doc="D.C. Code" path="§44-1703" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7019">Section 7019 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-202" path="§4">§ 4 of D.C. Law 21-202</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-202">D.C. Law 21-202</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§44-1703" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7019">Section 7019 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-202" path="§4">§ 4 of D.C. Law 21-202</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-202">D.C. Law 21-202</cite> have been given effect.
             </codify:annotation>
       </section>
       <section>
         <num>7020</num>
         <text>Section 4 of the Food, Environmental, and Economic Development in the District of Columbia Amendment Act of 2016, effective February 18, 2017 (D.C. Law 21-204; 63 DCR 15047), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-204" path="§4"/>
-        <codify:annotation doc="D.C. Code" path="§2-1212.01" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7020">Section 7020 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-204" path="§4">§ 4 of D.C. Law 21-204</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-204">D.C. Law 21-204</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§2-1212.01" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7020">Section 7020 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-204" path="§4">§ 4 of D.C. Law 21-204</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-204">D.C. Law 21-204</cite> have been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§2-1212.21a" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7020">Section 7020 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-204" path="§4">§ 4 of D.C. Law 21-204</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-204">D.C. Law 21-204</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="§2-1212.21a" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7020">Section 7020 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-204" path="§4">§ 4 of D.C. Law 21-204</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-204">D.C. Law 21-204</cite> has been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§47-3801" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7020">Section 7020 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-204" path="§4">§ 4 of D.C. Law 21-204</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-204">D.C. Law 21-204</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§47-3801" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7020">Section 7020 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-204" path="§4">§ 4 of D.C. Law 21-204</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-204">D.C. Law 21-204</cite> have been given effect.
             </codify:annotation>
       </section>
       <section>
         <num>7021</num>
         <text>Section 5 of the Automatic Voter Registration Amendment Act of 2016, effective February 18, 2017 (D.C. Law 21-208; 63 DCR 15285), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-208" path="§5"/>
-        <codify:annotation doc="D.C. Code" path="§1-1001.07" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7021">Section 7021 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-208" path="§5">§ 5 of D.C. Law 21-208</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-208">D.C. Law 21-208</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§1-1001.07" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7021">Section 7021 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-208" path="§5">§ 5 of D.C. Law 21-208</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-208">D.C. Law 21-208</cite> have been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§1-1061.06" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7021">Section 7021 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-208" path="§5">§ 5 of D.C. Law 21-208</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-208">D.C. Law 21-208</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§1-1061.06" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7021">Section 7021 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-208" path="§5">§ 5 of D.C. Law 21-208</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-208">D.C. Law 21-208</cite> have been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§50-1401.01c" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7021">Section 7021 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-208" path="§5">§ 5 of D.C. Law 21-208</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-208">D.C. Law 21-208</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="§50-1401.01c" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7021">Section 7021 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-208" path="§5">§ 5 of D.C. Law 21-208</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-208">D.C. Law 21-208</cite> has been given effect.
             </codify:annotation>
       </section>
       <section>
         <num>7022</num>
         <text>Section 4 of the Medical Marijuana Omnibus Amendment Act of 2016, effective February 18, 2017 (D.C. Law 21-209; 63 DCR 15291), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-209" path="§4"/>
-        <codify:annotation doc="D.C. Code" path="§7-1671.02" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7022">Section 7022 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-209" path="§4">§ 4 of D.C. Law 21-209</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-209">D.C. Law 21-209</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="§7-1671.02" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7022">Section 7022 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-209" path="§4">§ 4 of D.C. Law 21-209</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-209">D.C. Law 21-209</cite> has been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§7-1671.05" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7022">Section 7022 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-209" path="§4">§ 4 of D.C. Law 21-209</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-209">D.C. Law 21-209</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="§7-1671.05" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7022">Section 7022 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-209" path="§4">§ 4 of D.C. Law 21-209</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-209">D.C. Law 21-209</cite> has been given effect.
             </codify:annotation>
       </section>
       <section>
         <num>7023</num>
         <text>Section 5 of the Relocation Expenses Recoupment and Lien Authority Amendment Act of 2016, effective February 18, 2017 (D.C. Law 21-211; 63 DCR 15307), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-211" path="§5"/>
-        <codify:annotation doc="D.C. Code" path="§42-3531.04" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§42-3531.04" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> have been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§42-3531.10" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§42-3531.10" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> have been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§42-3531.11" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="§42-3531.11" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> has been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§42-3531.12" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="§42-3531.12" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> has been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§42-3531.13" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="§42-3531.13" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> has been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§42-3531.14" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="§42-3531.14" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> has been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§42-3531.15" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="§42-3531.15" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> has been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§42-3531.16" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="§42-3531.16" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> has been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§2-1831.03" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§2-1831.03" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> have been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§2-1215.15" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§2-1215.15" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7023">Section 7023 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-211" path="§5">§ 5 of D.C. Law 21-211</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-211">D.C. Law 21-211</cite> have been given effect.
             </codify:annotation>
       </section>
       <section>
         <num>7024</num>
         <text>Section 4 of the Department of Consumer and Regulatory Affairs Community Partnership Amendment Act of 2016, effective February 18, 2017 (D.C. Law 21-213; 63 DCR 15330), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-213" path="§4"/>
-        <codify:annotation doc="D.C. Code" path="§47-2851.02a" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7024">Section 7024 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-213" path="§4">§ 4 of D.C. Law 21-213</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-213">D.C. Law 21-213</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="§47-2851.02a" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7024">Section 7024 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-213" path="§4">§ 4 of D.C. Law 21-213</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-213">D.C. Law 21-213</cite> has been given effect.
             </codify:annotation>
       </section>
       <section>
         <num>7025</num>
         <text>Section 3 of the Planning Actively for Comprehensive Education Facilities Amendment Act of 2016, effective February 18, 2017 (D.C. Law 21-219; 63 DCMR 16023), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-219" path="§3"/>
-        <codify:annotation doc="D.C. Code" path="§2-1215.15" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7025">Section 7025 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-219" path="§3">§ 3 of D.C. Law 21-219</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-219">D.C. Law 21-219</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§2-1215.15" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7025">Section 7025 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-219" path="§3">§ 3 of D.C. Law 21-219</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-219">D.C. Law 21-219</cite> have been given effect.
             </codify:annotation>
       </section>
       <section>
@@ -8093,42 +8072,29 @@
             <codify:applicability path="§102|(e)|(3)|(C)" date="notfunded" history="false"/>
             <codify:applicability path="§102|(e)|(4)" date="notfunded" history="false"/>
             <codify:applicability path="§103" date="notfunded" history="false"/>
-            <!-- Notfunded provision is in section 204 of Law 21-238 -->
-            <codify:annotation doc="D.C. Code" path="§16-2310" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section.
+            <codify:annotation doc="D.C. Code" path="§16-2310" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section.
             </codify:annotation>
-             <codify:annotation doc="D.C. Code" path="§16-2312" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
+            <codify:annotation doc="D.C. Code" path="§16-2312" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
             </codify:annotation>
-            <codify:annotation doc="D.C. Code" path="§16-2313" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, retaining some of the applicability restrictions affecting this section, therefore those changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have not been given effect.
+            <codify:annotation doc="D.C. Code" path="§16-2313" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, retaining some of the applicability restrictions affecting this section, therefore those changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have not been given effect.
             </codify:annotation>
-            <codify:annotation doc="D.C. Code" path="§16-2320" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
+            <codify:annotation doc="D.C. Code" path="§16-2320" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
             </codify:annotation>
-            <codify:annotation doc="D.C. Code" path="§23-1322" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, retaining the applicability restrictions affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have not been given effect.
+            <codify:annotation doc="D.C. Code" path="§23-1322" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, retaining the applicability restrictions affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have not been given effect.
             </codify:annotation>
-            <codify:annotation doc="D.C. Code" path="§1-301.81" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
+            <codify:annotation doc="D.C. Code" path="§1-301.81" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
             </codify:annotation>
-            <codify:annotation doc="D.C. Code" path="§5-113.01" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
+            <codify:annotation doc="D.C. Code" path="§5-113.01" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
             </codify:annotation>
-            <codify:annotation doc="D.C. Code" path="§22-4234" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
+            <codify:annotation doc="D.C. Code" path="§22-4234" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
             </codify:annotation>
-            <codify:annotation doc="D.C. Code" path="§24-211.02" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
+            <codify:annotation doc="D.C. Code" path="§24-211.02" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
             </codify:annotation>
-            <codify:annotation doc="D.C. Code" path="§2-1515.04" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
+            <codify:annotation doc="D.C. Code" path="§2-1515.04" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
             </codify:annotation>
-            <codify:annotation doc="D.C. Code" path="§2-1515.04b" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
+            <codify:annotation doc="D.C. Code" path="§2-1515.04b" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended <cite doc="D.C. Law 21-238" path="§701|(a)">§ 701(a) of D.C. Law 21-238</cite>, removing the applicability restriction affecting this section, therefore the changes made to this section by <cite doc="D.C. Law 21-238">D.C. Law 21-238</cite> have been given effect.
             </codify:annotation>
-            <codify:annotation doc="D.C. Code" path="§24-913" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended section 701(a) of D.C. Law 21-238 providing that the creation of subsection (b) this section by § 204 of D.C. Law 21-238 is subject to the inclusion of the provision’s fiscal effect in an approved budget and financial plan. Therefore that amendment has not been given effect.
+            <codify:annotation doc="D.C. Code" path="§24-913" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7026">Section 7026 of D.C. Law 22-33</cite> amended section 701(a) of D.C. Law 21-238 providing that the creation of subsection (b) this section by § 204 of D.C. Law 21-238 is subject to the inclusion of the provision’s fiscal effect in an approved budget and financial plan. Therefore that amendment has not been given effect.
             </codify:annotation>
           </para>
         </include>
@@ -8138,56 +8104,47 @@
         <num>7027</num>
         <text>Section 3 of the Council Financial Disclosure Amendment Act of 2016, effective April 7, 2017 (D.C. Law 21-240; 64 DCR 1598), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-240" path="§3"/>
-        <codify:annotation doc="D.C. Code" path="§1-1162.24" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7027">Section 7027 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-240" path="§3">§ 3 of D.C. Law 21-240</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-240">D.C. Law 21-240</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§1-1162.24" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7027">Section 7027 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-240" path="§3">§ 3 of D.C. Law 21-240</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-240">D.C. Law 21-240</cite> have been given effect.
             </codify:annotation>
       </section>
       <section>
         <num>7028</num>
         <text>Section 3(a)(2), (b), and (c) of the Washington Metrorail Safety Commission Establishment Act of 2016, effective April 7, 2017 (D.C. Law 21-250; 64 DCR 1635), is repealed.</text>
       </section>
-      <!-- Notfunded provision is in Law 21-250 -->
       <section>
         <num>7029</num>
         <text>Section 6 of the State Board of Education Omnibus Amendment Act of 2016, effective April 7, 2017 (D.C. Law 21-252; 64 DCR 1656), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-252" path="§6"/>
-        <!-- Notfunded provision is in Law 21-252 -->
       </section>
       <section>
         <num>7030</num>
         <text>Section 4 of the Fair Credit in Employment Amendment Act of 2016, effective April 7, 2017 (D.C. Law 21-256; 64 DCR 2045), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-256" path="§4"/>
-        <codify:annotation doc="D.C. Code" path="§2-1402.11" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7030">Section 7030 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-256" path="§4">§ 4 of D.C. Law 21-256</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-256">D.C. Law 21-256</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§2-1402.11" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7030">Section 7030 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-256" path="§4">§ 4 of D.C. Law 21-256</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-256">D.C. Law 21-256</cite> have been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§2-1403.13" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7030">Section 7030 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-256" path="§4">§ 4 of D.C. Law 21-256</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-256">D.C. Law 21-256</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§2-1403.13" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7030">Section 7030 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-256" path="§4">§ 4 of D.C. Law 21-256</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-256">D.C. Law 21-256</cite> have been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§2-1411.03" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7030">Section 7030 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-256" path="§4">§ 4 of D.C. Law 21-256</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-256">D.C. Law 21-256</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§2-1411.03" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7030">Section 7030 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-256" path="§4">§ 4 of D.C. Law 21-256</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-256">D.C. Law 21-256</cite> have been given effect.
             </codify:annotation>
       </section>
       <section>
         <num>7031</num>
         <text>Section 11 of the Fair Criminal Record Screening for Housing Act of 2016, effective April 7, 2017 (D.C. Law 21-259; 64 DCR 2070), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-259" path="§11"/>
-        <codify:annotation doc="D.C. Code" path="42|35B" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7031">Section 7031 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-259" path="§11">§ 11 of D.C. Law 21-259</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-259">D.C. Law 21-259</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="42|35B" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7031">Section 7031 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-259" path="§11">§ 11 of D.C. Law 21-259</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-259">D.C. Law 21-259</cite> has been given effect.
             </codify:annotation>
       </section>
       <section>
         <num>7032</num>
         <text>Section 12 of the Office of Out of School Time Grants and Youth Outcomes Establishment Act of 2016, effective April 7, 2017 (D.C. Law 21-261; 64 DCR 2090), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-261" path="§12"/>
-        <codify:annotation doc="D.C. Code" path="2|15|III-B" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7032">Section 7032 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-261" path="§12">§ 12 of D.C. Law 21-261</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-261">D.C. Law 21-261</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="2|15|III-B" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7032">Section 7032 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-261" path="§12">§ 12 of D.C. Law 21-261</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-261">D.C. Law 21-261</cite> has been given effect.
             </codify:annotation>
         <codify:find-replace doc="D.C. Code" path="2|15|III-A" count="1">
           <find>Initiative.</find>
           <replace>Initiative. [Repealed]</replace>
         </codify:find-replace>
-        <codify:annotation doc="D.C. Code" path="2|15|III-A" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7032">Section 7032 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-261" path="§12">§ 12 of D.C. Law 21-261</cite>. Therefore the repeal of this section by <cite doc="D.C. Law 21-261">D.C. Law 21-261</cite> has been given effect.
+        <codify:annotation doc="D.C. Code" path="2|15|III-A" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7032">Section 7032 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-261" path="§12">§ 12 of D.C. Law 21-261</cite>. Therefore the repeal of this section by <cite doc="D.C. Law 21-261">D.C. Law 21-261</cite> has been given effect.
             </codify:annotation>
       </section>
       <section>
@@ -8204,11 +8161,9 @@
         <num>7035</num>
         <text>Section 3 of the First-time Homebuyer Tax Benefit Amendment Act of 2016, effective April 7, 2017 (D.C. Law 21-268; 64 DCR 2159), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-268" path="§3"/>
-        <codify:annotation doc="D.C. Code" path="§42-1101" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7035">Section 7035 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-268" path="§3">§ 3 of D.C. Law 21-268</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-268">D.C. Law 21-268</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§42-1101" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7035">Section 7035 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-268" path="§3">§ 3 of D.C. Law 21-268</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-268">D.C. Law 21-268</cite> have been given effect.
             </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§42-1103" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7035">Section 7035 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-268" path="§3">§ 3 of D.C. Law 21-268</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-268">D.C. Law 21-268</cite> have been given effect.
+        <codify:annotation doc="D.C. Code" path="§42-1103" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7035">Section 7035 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-268" path="§3">§ 3 of D.C. Law 21-268</cite>. Therefore the changes made to this section by <cite doc="D.C. Law 21-268">D.C. Law 21-268</cite> have been given effect.
             </codify:annotation>
       </section>
       <section>
@@ -8252,15 +8207,12 @@
         <num>7037</num>
         <text>Section 3 of the Continuing Care Retirement Community Exemption Amendment Act of 2016, effective April 15, 2017 (D.C. Law 21-274; 64 DCR 951), is repealed.</text>
         <codify:repeal doc="D.C. Law 21-274" path="§3"/>
-        <!-- Annotations in Law 21-274 -->
       </section>
       <section>
         <num>7038</num>
         <text>Section 7 of the Child Care Study Act of 2017, enacted on June 5, 2017 (D.C. Act 22-72; 64 DCR 5610), is repealed.</text>
-        <codify:annotation doc="D.C. Law 22-11" path="§7" type="Applicability" history="false">
-              <cite doc="D.C. Law 22-33" path="§7038">Section 7038 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-259" path="§11">§ 11 of D.C. Law 21-259</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-259">D.C. Law 21-259</cite> has been given effect.
+        <codify:annotation doc="D.C. Law 22-11" path="§7" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7038">Section 7038 of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-259" path="§11">§ 11 of D.C. Law 21-259</cite>. Therefore the creation of this section by <cite doc="D.C. Law 21-259">D.C. Law 21-259</cite> has been given effect.
             </codify:annotation>
-        <!-- Annotations in Law 22-11 -->
       </section>
     </container>
     <container>
@@ -8296,21 +8248,17 @@
       <section>
         <num>7046</num>
         <text>The Paramedic and Emergency Medical Technician Transition Amendment Act of 2008, effective March 31, 2009 (D.C. Law 17-356; 56 DCR 1614), is repealed.</text>
-        <!-- Done Researching -->
         <codify:repeal doc="D.C. Code" path="§5-409.01|(a-1)"/>
         <codify:repeal doc="D.C. Code" path="§5-701|(1)|(B)"/>
         <codify:find-replace doc="D.C. Code" path="§5-704">
           <find>Any member</find>
           <replace>Any member</replace>
         </codify:find-replace>
-        <codify:annotation doc="D.C. Code" path="§5-409.01" type="Effect of Amendments" history="false">
-          <cite doc="D.C. Law 22-33" path="§7046">Section 7046 of D.C. Law 22-33</cite> repealed Law 17-356.
+        <codify:annotation doc="D.C. Code" path="§5-409.01" type="Effect of Amendments" history="false"><cite doc="D.C. Law 22-33" path="§7046">Section 7046 of D.C. Law 22-33</cite> repealed Law 17-356.
         </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§5-701" type="Effect of Amendments" history="false">
-          <cite doc="D.C. Law 22-33" path="§7046">Section 7046 of D.C. Law 22-33</cite> repealed Law 17-356.
+        <codify:annotation doc="D.C. Code" path="§5-701" type="Effect of Amendments" history="false"><cite doc="D.C. Law 22-33" path="§7046">Section 7046 of D.C. Law 22-33</cite> repealed Law 17-356.
         </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§5-704" type="Effect of Amendments" history="false">
-          <cite doc="D.C. Law 22-33" path="§7046">Section 7046 of D.C. Law 22-33</cite> repealed Law 17-356.
+        <codify:annotation doc="D.C. Code" path="§5-704" type="Effect of Amendments" history="false"><cite doc="D.C. Law 22-33" path="§7046">Section 7046 of D.C. Law 22-33</cite> repealed Law 17-356.
         </codify:annotation>
       </section>
       <section>
@@ -8329,7 +8277,6 @@
         <codify:repeal doc="D.C. Code" path="§47-4631"/>
       </section>
       <section>
-        <!-- NA equitable tax relief -->
         <codify:ignore/>
         <num>7049</num>
         <text>The Shirley's Place Equitable Real Property Tax Relief Act of 2010, effective October 15, 2010 (D.C. Law 18-236; 57 DCR 7160), is repealed.</text>
@@ -8341,7 +8288,6 @@
       </section>
       <section>
         <codify:ignore/>
-        <!-- Amends over § 47-2005(11A), but overwritten by Law 20-61. -->
         <num>7051</num>
         <text>The Processing Sales Tax Clarification Act of 2010, effective March 12, 2011 (D.C. Law 18-324; 58 DCR 3), is repealed.</text>
       </section>
@@ -8462,8 +8408,7 @@
         <para>
           <num>(b)</num>
           <text>Section 6193 is repealed.</text>
-          <codify:annotation doc="D.C. Code" path="§35-233" type="Editor's Notes" history="false">
-            <cite doc="D.C. Law 22-33" path="§7072|(b)">Section 7072(b) of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-36" path="§6193">section 6193 of D.C. Law 21-36</cite> that had provided that section 6192 the act (which added (h)) shall expire on September 30, 2016.
+          <codify:annotation doc="D.C. Code" path="§35-233" type="Editor's Notes" history="false"><cite doc="D.C. Law 22-33" path="§7072|(b)">Section 7072(b) of D.C. Law 22-33</cite> repealed <cite doc="D.C. Law 21-36" path="§6193">section 6193 of D.C. Law 21-36</cite> that had provided that section 6192 the act (which added (h)) shall expire on September 30, 2016.
           </codify:annotation>
         </para>
       </section>
@@ -9155,7 +9100,6 @@
                   </tr>
                 </table>
               </text>
-              <!-- <text>.</text> -->
             </para>
           </include>
         </para>
@@ -9363,26 +9307,19 @@
         <num>7174</num>
         <heading>Applicability.</heading>
         <text>This subtitle shall apply as of January 1, 2018.</text>
-        <codify:annotation doc="D.C. Code" path="§47-1801.04" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
+        <codify:annotation doc="D.C. Code" path="§47-1801.04" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
         </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§47-1806.02" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
+        <codify:annotation doc="D.C. Code" path="§47-1806.02" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
         </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§47-1806.03" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
+        <codify:annotation doc="D.C. Code" path="§47-1806.03" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
         </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§47-1806.04" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
+        <codify:annotation doc="D.C. Code" path="§47-1806.04" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
         </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§47-1807.02" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
+        <codify:annotation doc="D.C. Code" path="§47-1807.02" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
         </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§47-1808.03" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
+        <codify:annotation doc="D.C. Code" path="§47-1808.03" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
         </codify:annotation>
-        <codify:annotation doc="D.C. Code" path="§47-3701" type="Applicability" history="false">
-          <cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
+        <codify:annotation doc="D.C. Code" path="§47-3701" type="Applicability" history="false"><cite doc="D.C. Law 22-33" path="§7174">Section 7174 of Law 22-33</cite> provided that the changes made to this section by Law 22-33 shall apply as of January 1, 2018.
         </codify:annotation>
       </section>
     </container>
@@ -9626,7 +9563,7 @@
             <text>Paragraph (4) is amended by striking the phrase "§ 10-1202.08" and inserting the phrase "§ 10-1202.08, and exclusive of any provision of law that dedicates any sales or parking tax revenues to the Washington Metropolitan Area Transit Authority" in its place.</text>
             <codify:find-replace count="1">
               <find> § <cite path="§10-1202.08">10-1202.08</cite></find>
-              <replace> <cite path="§10-1202.08">§ 10-1202.08</cite>, and exclusive of any provision of law that dedicates any sales or parking tax revenues to the Washington Metropolitan Area Transit Authority</replace>
+              <replace><cite path="§10-1202.08">§ 10-1202.08</cite>, and exclusive of any provision of law that dedicates any sales or parking tax revenues to the Washington Metropolitan Area Transit Authority</replace>
             </codify:find-replace>
           </para>
           <para codify:path="(25)">
@@ -10308,7 +10245,7 @@
           <text>Section 1262(b) (D.C. Official Code § 1-325.152(b)) is amended by striking the phrase "sections 1263a, and 1263b" and inserting the phrase "sections 1263a, 1263b, and 1263c" in its place.</text>
           <codify:find-replace count="1">
             <find>§§  <cite path="§1-325.153a">1-325.153a</cite> and <cite path="§1-325.153b">1-325.153b</cite></find>
-            <replace><span codify:value="§§ "></span><code-cite doc="D.C. Code" path="§1-325.153a" codify:value="1-325.153a">sections 1263a</code-cite>, <code-cite doc="D.C. Code" path="§1-325.153b" codify:value="1-325.153b">sections 1263b</code-cite>, and <code-cite doc="D.C. Code" path="§1-325.153c" codify:value="1-325.153c">sections 1263c</code-cite></replace>
+            <replace><span codify:value="§§ "/><code-cite doc="D.C. Code" path="§1-325.153a" codify:value="1-325.153a">sections 1263a</code-cite>, <code-cite doc="D.C. Code" path="§1-325.153b" codify:value="1-325.153b">sections 1263b</code-cite>, and <code-cite doc="D.C. Code" path="§1-325.153c" codify:value="1-325.153c">sections 1263c</code-cite></replace>
           </codify:find-replace>
         </para>
         <para codify:path="§1-325.153b|(a)">

--- a/schemas/annotation-types.xsd
+++ b/schemas/annotation-types.xsd
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='utf-8'?>
+<xs:schema
+  xmlns="https://code.dccouncil.us/schemas/dc-library"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://code.dccouncil.us/schemas/dc-library">
+  <xs:simpleType name="annotationTypes">
+    <!-- @summary: (annotation-types.xsd) annotationTypes type (via @summary) lorem ipsum. -->
+    <!-- @docs: types/annotationTypes.rst -->
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="History"/>
+      <xs:enumeration value="Prior Codifications"/>
+      <xs:enumeration value="Section References"/>
+      <xs:enumeration value="Effect of Amendments"/>
+      <xs:enumeration value="Cross References"/>
+      <xs:enumeration value="Expiration of Law"/>
+      <xs:enumeration value="Applicability"/>
+      <xs:enumeration value="Emergency Legislation"/>
+      <xs:enumeration value="Temporary Legislation"/>
+      <xs:enumeration value="Legislative History"/>
+      <xs:enumeration value="Short Title"/>
+      <xs:enumeration value="Transfer of Functions"/>
+      <xs:enumeration value="References in Text"/>
+      <xs:enumeration value="Effective Dates"/>
+      <xs:enumeration value="Editor's Notes"/>
+      <xs:enumeration value="Repeal of Law"/>
+      <xs:enumeration value="Mayor's Statement"/>
+      <xs:enumeration value="Mayor's Orders"/>
+      <xs:enumeration value="Delegation of Authority"/>
+      <xs:enumeration value="New Implementing Regulations"/>
+      <xs:enumeration value="Uniform Commercial Code Comment"/>
+      <xs:enumeration value="Change in Government"/>
+      <xs:enumeration value="Construction of Law"/>
+      <xs:enumeration value="Severability of Law"/>
+      <xs:enumeration value="Congressional Disapproval of Acts of the Council"/>
+      <xs:enumeration value="Resolutions"/>
+      <xs:enumeration value="Omission of Text"/>
+      <xs:enumeration value="Rules to implement law"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/schemas/annotation-types.xsd
+++ b/schemas/annotation-types.xsd
@@ -3,8 +3,7 @@
   xmlns="https://code.dccouncil.us/schemas/dc-library"
   xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://code.dccouncil.us/schemas/dc-library">
   <xs:simpleType name="annotationTypes">
-    <!-- @summary: (annotation-types.xsd) annotationTypes type (via @summary) lorem ipsum. -->
-    <!-- @docs: types/annotationTypes.rst -->
+    <!-- @summary: Specifies the type of annotation generated. -->
     <xs:restriction base="xs:string">
       <xs:enumeration value="History"/>
       <xs:enumeration value="Prior Codifications"/>

--- a/schemas/codify.xsd
+++ b/schemas/codify.xsd
@@ -205,6 +205,9 @@
       <xs:attribute name="num-value" type="xs:string" use="optional">
         <!-- @summary: Specify the number value of the transform result. Defaults to value of ``<num>``.-->
       </xs:attribute>
+      <xs:attribute name="destination-path" type="xs:string" use="optional">
+        <!-- @summary: path to destination container if the section should be moved (and not just renumbered) .-->
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="remove" type="anyType">

--- a/schemas/codify.xsd
+++ b/schemas/codify.xsd
@@ -1,28 +1,152 @@
-<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="https://code.dccouncil.us/schemas/codify"
-           xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           elementFormDefault="qualified"
-           targetNamespace="https://code.dccouncil.us/schemas/codify">
-  <xs:element name="annotation" type="xs:anyType"/>
-  <xs:element name="applicability" type="xs:anyType"/>
-  <xs:element name="expire" type="xs:anyType"/>
-  <xs:element name="create-sub-container" type="xs:anyType"/>
-  <xs:element name="find-replace" type="xs:anyType"/>
-  <xs:element name="funded-anno" type="xs:anyType"/>
-  <xs:element name="ignore" type="xs:anyType"/>
-  <xs:element name="insert" type="xs:anyType"/>
-  <xs:element name="insert-code-container" type="xs:anyType"/>
-  <xs:element name="not-funded-anno" type="xs:anyType"/>
-  <xs:element name="organic" type="xs:anyType"/>
-  <xs:element name="redesignate" type="xs:anyType"/>
-  <xs:element name="redesignate-para" type="xs:anyType"/>
-  <xs:element name="recodify-section" type="xs:anyType"/>
-  <xs:element name="remove" type="xs:anyType"/>
-  <xs:element name="repeal" type="xs:anyType"/>
-  <xs:element name="replace" type="xs:anyType"/>
-  <xs:element name="street-designation-anno" type="xs:anyType"/>
-  <xs:element name="temporary" type="xs:anyType"/>
-  <xs:element name="emergency" type="xs:anyType"/>
+<?xml version='1.0' encoding='utf-8'?>
+<xs:schema
+  xmlns="https://code.dccouncil.us/schemas/codify"
+  xmlns:p="https://code.dccouncil.us/schemas/dc-library"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://code.dccouncil.us/schemas/codify">
+  <xs:import namespace="https://code.dccouncil.us/schemas/dc-library" schemaLocation="dc-library.xsd"/>
+  <xs:element name="annotation">
+    <!-- an ignored comment -->
+    <!-- @docs: elements/annotation.rst -->
+    <!-- @docs: misc/some_file.rst -->
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="p:annotationType">
+          <xs:attributeGroup ref="sharedAttributes"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="applicability">
+    <!-- @summary: (codify.xsd) applicability element (via @summary 1) lorem ipsum. -->
+    <!-- @docs: elements/applicability_1.rst -->
+    <!-- @summary: (codify.xsd) applicability element (via @summary 2) lorem ipsum. -->
+    <!-- another ignored comment -->
+    <!-- @docs: elements/applicability_2.rst -->
+    <!-- @summary: (codify.xsd) applicability element (via @summary 3) lorem ipsum. -->
+    <xs:complexType>
+      <xs:attributeGroup ref="p:targetAttributes"/>
+      <xs:attributeGroup ref="sharedAttributes"/>
+      <xs:attribute name="action" type="xs:string" use="optional"/>
+      <xs:attribute name="date" type="xs:string" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="expire">
+    <xs:complexType>
+      <xs:attributeGroup ref="p:targetAttributes"/>
+      <xs:attributeGroup ref="sharedAttributes"/>
+      <xs:attribute name="date" type="xs:date" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="create-sub-container">
+    <xs:complexType>
+      <xs:attributeGroup ref="p:targetAttributes"/>
+      <xs:attributeGroup ref="sharedAttributes"/>
+      <xs:attribute name="heading-value" type="xs:string" use="optional"/>
+      <xs:attribute name="num-value" type="xs:string" use="optional"/>
+      <xs:attribute name="prefix-value" type="xs:string" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="emergency">
+    <xs:complexType>
+      <xs:attributeGroup ref="p:targetAttributes"/>
+      <xs:attributeGroup ref="sharedAttributes"/>
+      <xs:attribute name="action" type="xs:string" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="find-replace" type="findReplaceType"/>
+  <xs:element name="funded-anno">
+    <xs:complexType>
+      <xs:attributeGroup ref="p:targetAttributes"/>
+      <xs:attributeGroup ref="sharedAttributes"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ignore">
+    <xs:complexType>
+      <xs:attributeGroup ref="p:targetAttributes"/>
+      <xs:attributeGroup ref="sharedAttributes"/>
+      <xs:attribute name="technical" type="xs:string" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="insert">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="insertType">
+          <xs:attributeGroup ref="p:targetAttributes"/>
+          <xs:attributeGroup ref="sharedAttributes"/>
+          <xs:attribute name="after" type="xs:string" use="optional"/>
+          <xs:attribute name="before" type="xs:string" use="optional"/>
+          <xs:attribute name="num-value" type="xs:string" use="optional"/>
+          <xs:attribute name="technical" type="xs:string" use="optional"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="insert-code-container" type="anyType"/>
+  <xs:element name="not-funded-anno">
+    <xs:complexType>
+      <xs:attributeGroup ref="p:targetAttributes"/>
+      <xs:attributeGroup ref="sharedAttributes"/>
+      <xs:attribute name="action" type="xs:string" use="optional"/>
+      <xs:attribute name="applicability-path" type="xs:string" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="organic">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="insertType">
+          <xs:attributeGroup ref="p:targetAttributes"/>
+          <xs:attributeGroup ref="sharedAttributes"/>
+          <xs:attribute name="after" type="xs:string" use="optional"/>
+          <xs:attribute name="before" type="xs:string" use="optional"/>
+          <xs:attribute name="heading-value" type="xs:string" use="optional"/>
+          <xs:attribute name="num-value" type="xs:string" use="optional"/>
+          <xs:attribute name="prefix-value" type="xs:string" use="optional"/>
+          <xs:attribute name="tag" type="xs:string" use="optional"/>
+          <xs:attribute name="technical" type="xs:string" use="optional"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="redesignate" type="anyType"/>
+  <xs:element name="redesignate-para">
+    <xs:complexType>
+      <xs:attributeGroup ref="p:targetAttributes"/>
+      <xs:attributeGroup ref="sharedAttributes"/>
+      <xs:attribute name="num-value" type="xs:string" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="recodify-section">
+    <xs:complexType>
+      <xs:attributeGroup ref="p:targetAttributes"/>
+      <xs:attributeGroup ref="sharedAttributes"/>
+      <xs:attribute name="after" type="xs:string" use="optional"/>
+      <xs:attribute name="before" type="xs:string" use="optional"/>
+      <xs:attribute name="num-value" type="xs:string" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="remove" type="anyType"/>
+  <xs:element name="repeal">
+    <xs:complexType>
+      <xs:attributeGroup ref="p:targetAttributes"/>
+      <xs:attributeGroup ref="sharedAttributes"/>
+      <xs:attribute name="technical" type="xs:string" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="replace" type="anyType"/>
+  <xs:element name="street-designation-anno">
+    <xs:complexType>
+      <xs:attributeGroup ref="sharedAttributes"/>
+      <xs:attribute name="action" type="xs:string" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="temporary">
+    <xs:complexType>
+      <xs:attributeGroup ref="p:targetAttributes"/>
+      <xs:attributeGroup ref="sharedAttributes"/>
+      <xs:attribute name="action" type="xs:string" use="optional"/>
+      <xs:attribute name="emergency" type="xs:string" use="optional"/>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="any">
     <xs:complexType>
       <xs:sequence maxOccurs="unbounded">
@@ -30,22 +154,88 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+  <!-- types -->
+  <xs:complexType name="anyType">
+    <xs:complexContent>
+      <xs:extension base="xs:anyType">
+        <xs:attributeGroup ref="sharedAttributes"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="falseOnlyType">
+    <!-- @summary: (codify.xsd) falseOnlyType (via @summary) lorem ipsum. -->
+    <xs:restriction base="xs:string">
+      <xs:pattern value="false"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="findReplaceType">
+    <xs:sequence minOccurs="0">
+      <xs:element ref="p:find"/>
+      <xs:element ref="p:replace"/>
+    </xs:sequence>
+    <xs:attributeGroup ref="p:targetAttributes"/>
+    <xs:attributeGroup ref="findReplaceAttributes"/>
+    <xs:attributeGroup ref="sharedAttributes"/>
+    <xs:attribute name="count" type="xs:integer" use="optional"/>
+    <xs:attribute name="position" use="optional">
+      <xs:simpleType>
+        <xs:union memberTypes="xs:positiveInteger firstLastType"/>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="technical" type="xs:string" use="optional"/>
+  </xs:complexType>
+  <xs:simpleType name="firstLastType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="first"/>
+      <xs:enumeration value="last"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="insertType">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="create-sub-container"/>
+        <xs:element ref="insert"/>
+        <xs:element ref="recodify-section"/>
+        <xs:element ref="p:container"/>
+        <xs:element ref="p:section"/>
+        <xs:element ref="p:para"/>
+        <xs:element ref="p:text"/>
+        <xs:element ref="p:subsection"/>
+        <xs:element ref="p:toc"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+  <!-- attributes -->
   <xs:attribute name="applicability" type="xs:string"/>
   <xs:attribute name="doc" type="xs:string"/>
   <xs:attribute name="expire" type="xs:string"/>
   <xs:attribute name="instruction" type="xs:string"/>
   <xs:attribute name="path" type="xs:string"/>
+  <xs:attribute name="warning" type="falseOnlyType"/>
   <xs:attribute name="value" type="xs:string"/>
+  <!-- attribute groups -->
   <xs:attributeGroup name="allAttributes">
-    <xs:attribute ref="applicability" use="optional" />
-    <xs:attribute ref="doc" use="optional" />
+    <xs:attribute ref="applicability" use="optional"/>
+    <xs:attribute ref="doc" use="optional"/>
     <xs:attribute ref="expire" use="optional"/>
-    <xs:attribute ref="instruction" use="optional" />
-    <xs:attribute ref="path" use="optional" />
-    <xs:attribute ref="value" use="optional" />
+    <xs:attribute name="history" type="falseOnlyType" use="optional"/>
+    <xs:attribute name="history-prefix" type="xs:string" use="optional"/>
+    <xs:attribute ref="instruction" use="optional"/>
+    <xs:attribute ref="path" use="optional"/>
+    <xs:attribute ref="value" use="optional"/>
+    <xs:attribute name="warning" type="falseOnlyType" use="optional"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="findReplaceAttributes">
+    <xs:attribute name="find" type="xs:string" use="optional"/>
+    <xs:attribute name="replace" type="xs:string" use="optional"/>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="sharedAttributes">
+    <xs:attribute name="history" type="falseOnlyType" use="optional"/>
+    <xs:attribute name="history-prefix" type="xs:string" use="optional"/>
+    <xs:attribute name="warning" type="falseOnlyType" use="optional"/>
   </xs:attributeGroup>
   <xs:attributeGroup name="targetAttributes">
-    <xs:attribute ref="doc" use="optional" />
-    <xs:attribute ref="path" use="optional" />
+    <xs:attribute ref="doc" use="optional"/>
+    <xs:attribute ref="path" use="optional"/>
   </xs:attributeGroup>
 </xs:schema>

--- a/schemas/codify.xsd
+++ b/schemas/codify.xsd
@@ -6,8 +6,9 @@
   <xs:import namespace="https://code.dccouncil.us/schemas/dc-library" schemaLocation="dc-library.xsd"/>
   <xs:element name="annotation">
     <!-- an ignored comment -->
-    <!-- @docs: elements/annotation.rst -->
-    <!-- @docs: misc/some_file.rst -->
+    <!-- @summary: The ``<codify:annotation>`` instruction creates an annotation (or note) on the target element.-->
+    <!-- @docs: misc/examples_header.rst -->
+    <!-- @docs: examples/test_annotation.rst -->
     <xs:complexType>
       <xs:complexContent mixed="true">
         <xs:extension base="p:annotationType">
@@ -17,134 +18,238 @@
     </xs:complexType>
   </xs:element>
   <xs:element name="applicability">
-    <!-- @summary: (codify.xsd) applicability element (via @summary 1) lorem ipsum. -->
-    <!-- @docs: elements/applicability_1.rst -->
-    <!-- @summary: (codify.xsd) applicability element (via @summary 2) lorem ipsum. -->
-    <!-- another ignored comment -->
-    <!-- @docs: elements/applicability_2.rst -->
-    <!-- @summary: (codify.xsd) applicability element (via @summary 3) lorem ipsum. -->
+    <!-- @summary: The ``<codify:applicability>`` instruction is used to set the applicability status, including funding status, of the target element.  It is often used in connection with the ``<codify:not-funded-anno>`` when the applicability status is unfunded.-->
+    <!-- @docs: misc/examples_header.rst -->
+    <!-- @docs: examples/test_applicability_linear.rst -->
+    <!-- @docs: examples/test_applicability_pending.rst -->
     <xs:complexType>
       <xs:attributeGroup ref="p:targetAttributes"/>
       <xs:attributeGroup ref="sharedAttributes"/>
-      <xs:attribute name="action" type="xs:string" use="optional"/>
-      <xs:attribute name="date" type="xs:string" use="optional"/>
+      <xs:attribute name="action" type="xs:string" use="optional">
+        <!-- @summary: Specifies the applicability action. -->
+      </xs:attribute>
+      <xs:attribute name="date" type="xs:string" use="optional">
+        <!-- @summary: Specifies the applicability status, e.g. ``notfunded`` or ``pending``. -->
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="expire">
+    <!-- @summary: The ``<codify:expire>`` instruction is used to set the expiration date of the target element.  -->
+    <!-- @docs: misc/examples_header.rst -->
+    <!-- @docs: examples/test_expire_insert.rst -->
     <xs:complexType>
       <xs:attributeGroup ref="p:targetAttributes"/>
       <xs:attributeGroup ref="sharedAttributes"/>
-      <xs:attribute name="date" type="xs:date" use="optional"/>
+      <xs:attribute name="date" type="xs:date" use="optional">
+        <!-- @summary: Specify the date of expiration. -->
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="create-sub-container">
+    <!-- @summary: The ``<codify:create-sub-container>`` instruction is used in connection with the ``<codify:insert>`` instruction to create a sub-container simultaneous to inserting a new container. -->
+    <!-- @docs: misc/examples_header.rst -->
+    <!-- @docs: examples/test_create_sub_container.rst -->
     <xs:complexType>
       <xs:attributeGroup ref="p:targetAttributes"/>
       <xs:attributeGroup ref="sharedAttributes"/>
-      <xs:attribute name="heading-value" type="xs:string" use="optional"/>
-      <xs:attribute name="num-value" type="xs:string" use="optional"/>
-      <xs:attribute name="prefix-value" type="xs:string" use="optional"/>
+      <xs:attribute name="heading-value" type="xs:string" use="optional">
+        <!-- @summary: Specifies the text value of the heading, e.g. ``Hospital Assessments``. -->
+      </xs:attribute>
+      <xs:attribute name="num-value" type="xs:string" use="optional">
+        <!-- @summary: Specifies the number value of the heading, e.g. ``I``. -->
+      </xs:attribute>
+      <xs:attribute name="prefix-value" type="xs:string" use="optional">
+        <!-- @summary: Specifies the prefix text of the heading, e.g. ``Subchapter``. -->
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="emergency">
+    <!-- @summary: The ``<codify:emergency>`` marcro is used to generate an annotation relating to the codification of an emergency law.-->
     <xs:complexType>
       <xs:attributeGroup ref="p:targetAttributes"/>
       <xs:attributeGroup ref="sharedAttributes"/>
-      <xs:attribute name="action" type="xs:string" use="optional"/>
+      <xs:attribute name="action" type="xs:string" use="optional">
+        <!-- @summary: Specifies the action text to be included in the generated annotation. -->
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
-  <xs:element name="find-replace" type="findReplaceType"/>
+  <xs:element name="find-replace" type="findReplaceType">
+    <!-- @summary: The ``<codify:find-replace>`` instruction finds text at the target node and replaces the text at the target with new text. -->
+    <!-- @docs: misc/examples_header.rst -->
+    <!-- @docs: examples/test_find_replace.rst -->
+    <!-- @docs: examples/test_find_replace_rich_text.rst -->
+    <!-- @docs: examples/test_find_replace_first.rst -->
+    <!-- @docs: examples/test_find_replace_last.rst -->
+  </xs:element>
   <xs:element name="funded-anno">
+    <!-- @summary: The ``<codify:funded-anno>`` macro is used to generate an annotation for the target element indicating that the target element has been funded.-->
     <xs:complexType>
       <xs:attributeGroup ref="p:targetAttributes"/>
       <xs:attributeGroup ref="sharedAttributes"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="ignore">
+    <!-- @summary: The ``<codify:ignore>`` instruction is used to expressly indicate that a particular portion of the law will not be codified. -->
     <xs:complexType>
       <xs:attributeGroup ref="p:targetAttributes"/>
       <xs:attributeGroup ref="sharedAttributes"/>
-      <xs:attribute name="technical" type="xs:string" use="optional"/>
+      <xs:attribute name="technical" type="xs:string" use="optional">
+        <!-- @summary: Specifies a technical change to the transform that is different from the instruction provided by the law.-->
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="insert">
+    <!-- @summary: The ``<codify:insert>`` instruction is used to insert an element (and its children) as a child of the specified target. It can, for instance, insert a new container into the code, insert a new section into an existing law, or insert a new paragraph into an existing section.-->
+    <!-- @docs: misc/examples_header.rst -->
+    <!-- @docs: examples/test_insert.rst -->
+    <!-- @docs: examples/test_insert_organic.rst -->
+    <!-- @docs: examples/test_insert_before_after.rst -->
     <xs:complexType>
       <xs:complexContent>
         <xs:extension base="insertType">
           <xs:attributeGroup ref="p:targetAttributes"/>
           <xs:attributeGroup ref="sharedAttributes"/>
-          <xs:attribute name="after" type="xs:string" use="optional"/>
-          <xs:attribute name="before" type="xs:string" use="optional"/>
-          <xs:attribute name="num-value" type="xs:string" use="optional"/>
-          <xs:attribute name="technical" type="xs:string" use="optional"/>
+          <xs:attribute name="after" type="xs:string" use="optional">
+            <!-- @summary: Specify the child element at the target path that the transform results should appear after. -->
+          </xs:attribute>
+          <xs:attribute name="before" type="xs:string" use="optional">
+            <!-- @summary: Specify the child element at the target path that the transform results should appear before. -->
+          </xs:attribute>
+          <xs:attribute name="num-value" type="xs:string" use="optional">
+            <!-- @summary: Specify the number value of the transform result. Defaults to value of ``<num>``.-->
+          </xs:attribute>
+          <xs:attribute name="technical" type="xs:string" use="optional">
+            <!-- @summary: Specifies a technical change to the transform that is different from the instruction provided by the law.-->
+          </xs:attribute>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  <xs:element name="insert-code-container" type="anyType"/>
+  <xs:element name="insert-code-container" type="anyType">
+    <!-- @summary: Pending discussion on use.-->
+  </xs:element>
   <xs:element name="not-funded-anno">
+    <!-- @summary: The ``<codify:not-funded-anno>`` macro is used to generate an annotation for the target element indicating that the target element is not funded.-->
     <xs:complexType>
       <xs:attributeGroup ref="p:targetAttributes"/>
       <xs:attributeGroup ref="sharedAttributes"/>
-      <xs:attribute name="action" type="xs:string" use="optional"/>
-      <xs:attribute name="applicability-path" type="xs:string" use="optional"/>
+      <xs:attribute name="action" type="xs:string" use="optional">
+        <!-- @summary: Specifies the action text to be included in the generated annotation, e.g. ``the addition of``, ``creation of``, ``addition of section``, etc. -->
+      </xs:attribute>
+      <xs:attribute name="applicability-path" type="xs:string" use="optional">
+        <!-- @summary: Specifies the path to section with applicability provision.-->
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="organic">
+    <!-- @summary: The ``<codify:organic>`` is no longer used.-->
+    <!-- @summary: The ``<codify:organic>`` instruction is used to codify an organic law.-->
     <xs:complexType>
       <xs:complexContent>
         <xs:extension base="insertType">
           <xs:attributeGroup ref="p:targetAttributes"/>
           <xs:attributeGroup ref="sharedAttributes"/>
-          <xs:attribute name="after" type="xs:string" use="optional"/>
-          <xs:attribute name="before" type="xs:string" use="optional"/>
-          <xs:attribute name="heading-value" type="xs:string" use="optional"/>
-          <xs:attribute name="num-value" type="xs:string" use="optional"/>
-          <xs:attribute name="prefix-value" type="xs:string" use="optional"/>
-          <xs:attribute name="tag" type="xs:string" use="optional"/>
-          <xs:attribute name="technical" type="xs:string" use="optional"/>
+          <xs:attribute name="after" type="xs:string" use="optional">
+            <!-- @summary: Specify the child element at the target path that the transform results should appear after. -->
+          </xs:attribute>
+          <xs:attribute name="before" type="xs:string" use="optional">
+            <!-- @summary: Specify the child element at the target path that the transform results should appear before. -->
+          </xs:attribute>
+          <xs:attribute name="heading-value" type="xs:string" use="optional">
+            <!-- @summary: Specifies the text value of the heading, e.g. ``Hospital Assessments``. -->
+          </xs:attribute>
+          <xs:attribute name="num-value" type="xs:string" use="optional">
+            <!-- @summary: Specify the number value of the transform result. Defaults to value of ``<num>``.-->
+          </xs:attribute>
+          <xs:attribute name="prefix-value" type="xs:string" use="optional">
+            <!-- @summary: Specifies the prefix text of the heading, e.g. ``Subchapter``. -->
+          </xs:attribute>
+          <xs:attribute name="tag" type="xs:string" use="optional">
+            <!-- @summary: Specifies the type of element to be inserted, e.g. ``<container>``.-->
+          </xs:attribute>
+          <xs:attribute name="technical" type="xs:string" use="optional">
+            <!-- @summary: Specifies a technical change to the transform that is different from the instruction provided by the law.-->
+          </xs:attribute>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  <xs:element name="redesignate" type="anyType"/>
+  <xs:element name="redesignate" type="anyType">
+    <!-- @summary: Pending discussion on use.-->
+  </xs:element>
   <xs:element name="redesignate-para">
+    <!-- @summary: The ``<codify:redesignate-para>`` instruction changes the value of the target paragraph number from one value to another.-->
+    <!-- @docs: misc/examples_header.rst -->
+    <!-- @docs: examples/test_redesignate_para_on_section.rst -->
     <xs:complexType>
       <xs:attributeGroup ref="p:targetAttributes"/>
       <xs:attributeGroup ref="sharedAttributes"/>
-      <xs:attribute name="num-value" type="xs:string" use="optional"/>
+      <xs:attribute name="num-value" type="xs:string" use="optional">
+        <!-- @summary: Specify the number value of the transform result. Defaults to value of ``<num>``.-->
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="recodify-section">
+    <!-- @summary: The ``<codify:recodify-section>`` instruction recodifies the target in the code into a new section of the code.-->
+    <!-- @docs: misc/examples_header.rst -->
+    <!-- @docs: examples/test_recodify_code_section.rst -->
     <xs:complexType>
       <xs:attributeGroup ref="p:targetAttributes"/>
       <xs:attributeGroup ref="sharedAttributes"/>
-      <xs:attribute name="after" type="xs:string" use="optional"/>
-      <xs:attribute name="before" type="xs:string" use="optional"/>
-      <xs:attribute name="num-value" type="xs:string" use="optional"/>
+      <xs:attribute name="after" type="xs:string" use="optional">
+        <!-- @summary: Specify the child element at the target path that the transform results should appear after. -->
+      </xs:attribute>
+      <xs:attribute name="before" type="xs:string" use="optional">
+        <!-- @summary: Specify the child element at the target path that the transform results should appear before. -->
+      </xs:attribute>
+      <xs:attribute name="num-value" type="xs:string" use="optional">
+        <!-- @summary: Specify the number value of the transform result. Defaults to value of ``<num>``.-->
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
-  <xs:element name="remove" type="anyType"/>
+  <xs:element name="remove" type="anyType">
+    <!-- @summary: The ``<codify:remove>`` instruction removes the target element.-->
+    <!-- @docs: misc/examples_header.rst -->
+    <!-- @docs: examples/test_remove.rst -->
+  </xs:element>
   <xs:element name="repeal">
+    <!-- @summary: The ``<codify:repeal>`` instruction repeals the target element.-->
+    <!-- @docs: misc/examples_header.rst -->
+    <!-- @docs: examples/test_repeal.rst -->
+    <!-- @docs: examples/test_repeal_enacted.rst -->
     <xs:complexType>
       <xs:attributeGroup ref="p:targetAttributes"/>
       <xs:attributeGroup ref="sharedAttributes"/>
-      <xs:attribute name="technical" type="xs:string" use="optional"/>
+      <xs:attribute name="technical" type="xs:string" use="optional">
+        <!-- @summary: Specifies a technical change to the transform that is different from the instruction provided by the law.-->
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
-  <xs:element name="replace" type="anyType"/>
+  <xs:element name="replace" type="anyType">
+    <!-- @summary: The ``<codify:replace>`` instruction replaces the target element with the contents of the instructions parent element.-->
+    <!-- @docs: misc/examples_header.rst -->
+    <!-- @docs: examples/test_replace.rst -->
+  </xs:element>
   <xs:element name="street-designation-anno">
+    <!-- @summary: The ``<codify:street-designation-anno>`` macro is used when the council designates new streets.-->
     <xs:complexType>
       <xs:attributeGroup ref="sharedAttributes"/>
-      <xs:attribute name="action" type="xs:string" use="optional"/>
+      <xs:attribute name="action" type="xs:string" use="optional">
+        <!-- @summary: Specifies the action text to be included in the generated annotation, e.g. ``the Council designates``.-->
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="temporary">
+    <!-- @summary: The ``<codify:temporary>`` macro is used to codify temporary laws.-->
     <xs:complexType>
       <xs:attributeGroup ref="p:targetAttributes"/>
       <xs:attributeGroup ref="sharedAttributes"/>
-      <xs:attribute name="action" type="xs:string" use="optional"/>
-      <xs:attribute name="emergency" type="xs:string" use="optional"/>
+      <xs:attribute name="action" type="xs:string" use="optional">
+        <!-- @summary: Specifies the action text to be included in the generated annotation, e.g. ``the addition of a new section``, ``amendment to the Expansion and Coordination of Youth Services Act of 2016``, etc.-->
+      </xs:attribute>
+      <xs:attribute name="emergency" type="xs:string" use="optional">
+        <!-- @summary: No longer used. -->
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="any">
@@ -163,7 +268,7 @@
     </xs:complexContent>
   </xs:complexType>
   <xs:simpleType name="falseOnlyType">
-    <!-- @summary: (codify.xsd) falseOnlyType (via @summary) lorem ipsum. -->
+    <!-- @internalTarget: appendix_falseOnlyType -->
     <xs:restriction base="xs:string">
       <xs:pattern value="false"/>
     </xs:restriction>
@@ -176,13 +281,18 @@
     <xs:attributeGroup ref="p:targetAttributes"/>
     <xs:attributeGroup ref="findReplaceAttributes"/>
     <xs:attributeGroup ref="sharedAttributes"/>
-    <xs:attribute name="count" type="xs:integer" use="optional"/>
+    <xs:attribute name="count" type="xs:integer" use="optional">
+      <!-- @summary: Specifies the number of instances the ``find`` value exists at the target. -->
+    </xs:attribute>
     <xs:attribute name="position" use="optional">
+      <!-- @summary: Specifies position of the ``find`` value in the target element, e.g. ``last``, ``first``, ``heading``, or ``text``. -->
       <xs:simpleType>
         <xs:union memberTypes="xs:positiveInteger firstLastType"/>
       </xs:simpleType>
     </xs:attribute>
-    <xs:attribute name="technical" type="xs:string" use="optional"/>
+    <xs:attribute name="technical" type="xs:string" use="optional">
+      <!-- @summary: Specifies a technical change to the transform that is different from the instruction provided by the law.-->
+    </xs:attribute>
   </xs:complexType>
   <xs:simpleType name="firstLastType">
     <xs:restriction base="xs:string">
@@ -226,13 +336,23 @@
     <xs:attribute name="warning" type="falseOnlyType" use="optional"/>
   </xs:attributeGroup>
   <xs:attributeGroup name="findReplaceAttributes">
-    <xs:attribute name="find" type="xs:string" use="optional"/>
-    <xs:attribute name="replace" type="xs:string" use="optional"/>
+    <xs:attribute name="find" type="xs:string" use="optional">
+      <!-- @summary: Specifies the text to be found at the target. -->
+    </xs:attribute>
+    <xs:attribute name="replace" type="xs:string" use="optional">
+      <!-- @summary: Specifies the replacement text. -->
+    </xs:attribute>
   </xs:attributeGroup>
   <xs:attributeGroup name="sharedAttributes">
-    <xs:attribute name="history" type="falseOnlyType" use="optional"/>
-    <xs:attribute name="history-prefix" type="xs:string" use="optional"/>
-    <xs:attribute name="warning" type="falseOnlyType" use="optional"/>
+    <xs:attribute name="history" type="falseOnlyType" use="optional">
+      <!-- @summary: Setting ``history=false`` to prevent creation of a history entry.-->
+    </xs:attribute>
+    <xs:attribute name="history-prefix" type="xs:string" use="optional">
+      <!-- @summary: Prepends the attribute value to the history entry's text. -->
+    </xs:attribute>
+    <xs:attribute name="warning" type="falseOnlyType" use="optional">
+      <!-- @summary: Set ``warning=false`` to prevent warning when applying this transform. -->
+    </xs:attribute>
   </xs:attributeGroup>
   <xs:attributeGroup name="targetAttributes">
     <xs:attribute ref="doc" use="optional"/>

--- a/schemas/dc-library.xsd
+++ b/schemas/dc-library.xsd
@@ -137,8 +137,7 @@
     </xs:complexType>
   </xs:element>
   <xs:element name="find">
-    <!-- @internalTarget: appendix_find -->
-    <!-- @summary: (dc-library.xsd) find element (via @summary) lorem ipsum. -->
+    <!-- @summary: Specifies the text or xml to be found at the target. -->
     <xs:complexType>
       <xs:complexContent mixed="true">
         <xs:extension base="xs:anyType">
@@ -289,8 +288,7 @@
   <xs:element name="prefix" type="xs:string"/>
   <xs:element name="reason" type="xs:string"/>
   <xs:element name="replace">
-    <!-- @summary: (dc-library.xsd) replace element (via @summary) lorem ipsum. -->
-    <!-- @internalTarget: appendix_replace -->
+    <!-- @summary: Specifies the replacement text or xml. -->
     <xs:complexType>
       <xs:complexContent mixed="true">
         <xs:extension base="xs:anyType">
@@ -410,14 +408,11 @@
   </xs:complexType>
   <!-- attribute groups -->
   <xs:attributeGroup name="targetAttributes">
-    <!-- @summary: (dc-library.xsd) targetAttributes attributeGroup (via @summary) lorem ipsum. -->
     <xs:attribute name="doc" type="xs:string" use="optional">
-      <!-- @docs: attributes/doc.rst -->
-      <!-- @summary: (dc-library.xsd) targetAttributes doc attribute (via @summary) lorem ipsum. -->
+      <!-- @summary: The ``doc`` and ``path`` attributes together determine the target of the transform. :ref:`Learn more here <appendix_docAndPath>`. -->
     </xs:attribute>
     <xs:attribute name="path" type="xs:string" use="optional">
-      <!-- @summary: (dc-library.xsd) targetAttributes path attribute (via @summary) lorem ipsum. -->
-      <!-- @docs: attributes/path.rst -->
+      <!-- @summary: The ``doc`` and ``path`` attributes together determine the target of the transform. :ref:`Learn more here <appendix_docAndPath>`. -->
     </xs:attribute>
   </xs:attributeGroup>
 </xs:schema>

--- a/schemas/dc-library.xsd
+++ b/schemas/dc-library.xsd
@@ -1,8 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
-<xs:schema xmlns="https://code.dccouncil.us/schemas/dc-library" xmlns:codified="https://code.dccouncil.us/schemas/codified" xmlns:codify="https://code.dccouncil.us/schemas/codify" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://code.dccouncil.us/schemas/dc-library">
+<xs:schema
+  xmlns="https://code.dccouncil.us/schemas/dc-library"
+  xmlns:codified="https://code.dccouncil.us/schemas/codified"
+  xmlns:codify="https://code.dccouncil.us/schemas/codify"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="https://code.dccouncil.us/schemas/dc-library">
   <xs:import namespace="https://code.dccouncil.us/schemas/codified" schemaLocation="codified.xsd"/>
   <xs:import namespace="https://code.dccouncil.us/schemas/codify" schemaLocation="codify.xsd"/>
   <xs:import namespace="http://www.w3.org/2001/XInclude" schemaLocation="XInclude.xsd"/>
+  <xs:include schemaLocation="./annotation-types.xsd"/>
   <xs:element name="aftertext">
     <xs:complexType>
       <xs:complexContent mixed="true">
@@ -12,49 +18,7 @@
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  <xs:element name="annotation">
-    <xs:complexType>
-      <xs:complexContent mixed="true">
-        <xs:extension base="xs:anyType">
-          <xs:attributeGroup ref="targetAttributes"/>
-          <xs:attribute name="type" use="required">
-            <xs:simpleType>
-              <xs:restriction base="xs:string">
-                <xs:enumeration value="History"/>
-                <xs:enumeration value="Prior Codifications"/>
-                <xs:enumeration value="Section References"/>
-                <xs:enumeration value="Effect of Amendments"/>
-                <xs:enumeration value="Cross References"/>
-                <xs:enumeration value="Expiration of Law"/>
-                <xs:enumeration value="Applicability"/>
-                <xs:enumeration value="Emergency Legislation"/>
-                <xs:enumeration value="Temporary Legislation"/>
-                <xs:enumeration value="Legislative History"/>
-                <xs:enumeration value="Short Title"/>
-                <xs:enumeration value="Transfer of Functions"/>
-                <xs:enumeration value="References in Text"/>
-                <xs:enumeration value="Effective Dates"/>
-                <xs:enumeration value="Editor's Notes"/>
-                <xs:enumeration value="Repeal of Law"/>
-                <xs:enumeration value="Mayor's Statement"/>
-                <xs:enumeration value="Mayor's Orders"/>
-                <xs:enumeration value="Delegation of Authority"/>
-                <xs:enumeration value="New Implementing Regulations"/>
-                <xs:enumeration value="Uniform Commercial Code Comment"/>
-                <xs:enumeration value="Change in Government"/>
-                <xs:enumeration value="Construction of Law"/>
-                <xs:enumeration value="Severability of Law"/>
-                <xs:enumeration value="Congressional Disapproval of Acts of the Council"/>
-                <xs:enumeration value="Resolutions"/>
-                <xs:enumeration value="Omission of Text"/>
-                <xs:enumeration value="Rules to implement law"/>
-              </xs:restriction>
-            </xs:simpleType>
-          </xs:attribute>
-        </xs:extension>
-      </xs:complexContent>
-    </xs:complexType>
-  </xs:element>
+  <xs:element name="annotation" type="annotationType"/>
   <xs:element name="annotations">
     <xs:complexType>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
@@ -104,18 +68,6 @@
       <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>
   </xs:element>
-  <xs:complexType name="sectionContainer">
-    <xs:sequence>
-      <xs:element ref="prefix" minOccurs="0"/>
-      <xs:element ref="num" minOccurs="0"/>
-      <xs:element ref="heading"/>
-      <xs:choice maxOccurs="unbounded">
-        <xs:element name="container" type="sectionContainer"/>
-        <xs:element ref="para"/>
-          <xs:element ref="text"/>
-      </xs:choice>
-    </xs:sequence>
-  </xs:complexType>
   <xs:element name="container">
     <xs:complexType>
       <xs:sequence>
@@ -182,6 +134,17 @@
           <xs:attribute name="projected" type="xs:boolean" use="optional"/>
         </xs:extension>
       </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="find">
+    <!-- @internalTarget: appendix_find -->
+    <!-- @summary: (dc-library.xsd) find element (via @summary) lorem ipsum. -->
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xs:anyType">
+          <xs:attributeGroup ref="targetAttributes"/>
+        </xs:extension>
+      </xs:complexContent>
     </xs:complexType>
   </xs:element>
   <xs:element name="page">
@@ -304,7 +267,11 @@
   <xs:element name="para">
     <xs:complexType>
       <xs:sequence>
-        <xs:any namespace="https://code.dccouncil.us/schemas/codify" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="codify:insert"/>
+          <xs:element ref="codify:organic"/>
+          <xs:element ref="codify:repeal"/>
+        </xs:choice>
         <xs:element ref="prefix" minOccurs="0"/>
         <xs:element ref="num" minOccurs="1"/>
         <xs:element ref="heading" minOccurs="0"/>
@@ -321,10 +288,21 @@
   </xs:element>
   <xs:element name="prefix" type="xs:string"/>
   <xs:element name="reason" type="xs:string"/>
+  <xs:element name="replace">
+    <!-- @summary: (dc-library.xsd) replace element (via @summary) lorem ipsum. -->
+    <!-- @internalTarget: appendix_replace -->
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xs:anyType">
+          <xs:attributeGroup ref="targetAttributes"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="subsection">
     <xs:complexType>
       <xs:sequence>
-            <xs:element ref="num"/>
+        <xs:element ref="num"/>
         <xs:element ref="heading" minOccurs="0"/>
         <xs:element ref="text" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element ref="para" minOccurs="0" maxOccurs="unbounded"/>
@@ -348,19 +326,6 @@
       <xs:attributeGroup ref="codify:allAttributes"/>
     </xs:complexType>
   </xs:element>
-  <xs:group name="sectionContents">
-    <xs:sequence>
-      <xs:element ref="heading" minOccurs="0"/>
-      <xs:element ref="text" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element ref="toc" minOccurs="0"/>
-      <xs:element ref="include" minOccurs="0"/>
-      <xs:element name="container" type="sectionContainer" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element ref="para" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element ref="aftertext" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element ref="annotations" minOccurs="0"/>
-      <xs:element ref="annotation" minOccurs="0" maxOccurs="unbounded"/>
-    </xs:sequence>
-  </xs:group>
   <xs:element name="text">
     <xs:complexType>
       <xs:complexContent mixed="true">
@@ -383,6 +348,29 @@
       <xs:attributeGroup ref="codify:allAttributes"/>
     </xs:complexType>
   </xs:element>
+  <!-- groups -->
+  <xs:group name="sectionContents">
+    <xs:sequence>
+      <xs:element ref="heading" minOccurs="0"/>
+      <xs:element ref="text" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="toc" minOccurs="0"/>
+      <xs:element ref="include" minOccurs="0"/>
+      <xs:element name="container" type="sectionContainer" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="para" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="aftertext" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="annotations" minOccurs="0"/>
+      <xs:element ref="annotation" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:group>
+  <!-- types -->
+  <xs:complexType name="annotationType">
+    <xs:complexContent mixed="true">
+      <xs:extension base="xs:anyType">
+        <xs:attributeGroup ref="targetAttributes"/>
+        <xs:attribute name="type" type="annotationTypes" use="required"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
   <xs:simpleType name="date-or-empty">
     <xs:union memberTypes="xs:date empty-string"/>
   </xs:simpleType>
@@ -391,6 +379,18 @@
       <xs:enumeration value=""/>
     </xs:restriction>
   </xs:simpleType>
+  <xs:complexType name="sectionContainer">
+    <xs:sequence>
+      <xs:element ref="prefix" minOccurs="0"/>
+      <xs:element ref="num" minOccurs="0"/>
+      <xs:element ref="heading"/>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element name="container" type="sectionContainer"/>
+        <xs:element ref="para"/>
+        <xs:element ref="text"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
   <xs:complexType name="tocContainer">
     <xs:sequence>
       <xs:element ref="prefix" minOccurs="0"/>
@@ -408,8 +408,16 @@
       <xs:element ref="heading"/>
     </xs:sequence>
   </xs:complexType>
+  <!-- attribute groups -->
   <xs:attributeGroup name="targetAttributes">
-    <xs:attribute name="doc" type="xs:string" use="optional"/>
-    <xs:attribute name="path" type="xs:string" use="optional"/>
+    <!-- @summary: (dc-library.xsd) targetAttributes attributeGroup (via @summary) lorem ipsum. -->
+    <xs:attribute name="doc" type="xs:string" use="optional">
+      <!-- @docs: attributes/doc.rst -->
+      <!-- @summary: (dc-library.xsd) targetAttributes doc attribute (via @summary) lorem ipsum. -->
+    </xs:attribute>
+    <xs:attribute name="path" type="xs:string" use="optional">
+      <!-- @summary: (dc-library.xsd) targetAttributes path attribute (via @summary) lorem ipsum. -->
+      <!-- @docs: attributes/path.rst -->
+    </xs:attribute>
   </xs:attributeGroup>
 </xs:schema>

--- a/schemas/dc-library.xsd
+++ b/schemas/dc-library.xsd
@@ -269,7 +269,9 @@
         <xs:choice minOccurs="0" maxOccurs="unbounded">
           <xs:element ref="codify:insert"/>
           <xs:element ref="codify:organic"/>
-          <xs:element ref="codify:repeal"/>
+          <xs:element ref="codify:replace"/>
+          <xs:element ref="codify:ignore"/>
+          <xs:element ref="codify:temporary"/>
         </xs:choice>
         <xs:element ref="prefix" minOccurs="0"/>
         <xs:element ref="num" minOccurs="1"/>


### PR DESCRIPTION
(squashed from [augb/codify-schema-updates](https://github.com/DCCouncil/dc-law-xml/pull/115)) ...

Closes openlawlibrary/OpenLawPlatform#44.

* Make `<codify:find-replace>` element more closely match reality.

* Replace `warning` attribute with `shardAttributeGroup` on `<codify:*>`.

* Formatting.

* Restrict para codify elements at the start to insert, organic and repeal.

* Remove `emptyType`, as not needed ...

* Add `history` attributes to `AllAttributes` group.

* Set spacing to 2 characters.

* Rename `historyAttributes` to `sharedAttributes`; add `warning` to this.

* Make `<codify:street-designation-anno>` element more closely match reality.

* Make `<codify:temporary>` element more closely match reality.

* Make `<codify:recodify-section>` element more closely match reality.

* Make `<codify:redesignate-para>` element more closely match reality.

* Make `<codify:organic>` element more closely match reality.

* Make `<codify:not-funded-anno>` element more closely match reality.

* Make `<codify:ignore>` element more closely match reality.

* Make `<codify:funded-anno>` element more closely match reality.

* Make `<codify:create-sub-container>` element more closely match reality.

* Make `<codify:expire>` element more closely match reality.

* Make `<codify:applicability>` element more closely match reality.

* Add new `annotationType` to library schema; base `codify:annotation` off of it.

* Convert `history` attribute to use `falseOnlyType`.

* Convert `warning` attribute to new `falseOnlyType`.

* Remove `codify:doc` and `codify:path` attributes from `<codify>` elements.

* Make `<codify:repeal>` element more closely match reality.

* Add `emptyType` to library schema; organize types and groups.

* Add `historyAttributes` attribute group to codify schema.

* Make `<codify:insert>` element more closely match reality.