### PR TITLE
clean up history annos; fix 1-96 date

### DIFF
--- a/dc/council/periods/1/laws/1-96.xml
+++ b/dc/council/periods/1/laws/1-96.xml
@@ -2,10 +2,10 @@
 <document xmlns="https://code.dccouncil.us/schemas/dc-library" xmlns:codified="https://code.dccouncil.us/schemas/codified" xmlns:codify="https://code.dccouncil.us/schemas/codify" xmlns:xi="http://www.w3.org/2001/XInclude" id="D.C. Law 1-96" flag="true">
   <num type="law">1-96</num>
   <meta>
-    <effective>1977-03-25</effective>
+    <effective>1977-03-29</effective>
     <citations>
       <citation type="law" url="./docs/1-96.pdf">D.C. Law 1-96</citation>
-      <citation type="register">23 DCR 9532</citation>
+      <citation type="register">23 DCR 3744</citation>
     </citations>
     <history>
       <narrative>Law 1-96 was introduced in Council and assigned Bill No. 1-119, which was referred to the Committee on the Judiciary and the Committee on Criminal Law. The Bill was adopted on first and second readings on September 15, 1976 and October 12, 1976, respectively. Signed by the Mayor on November 19, 1976, it was assigned Act No. 1-178 and transmitted to both Houses of Congress for its review.</narrative>

--- a/dc/council/periods/19/laws/19-311.xml
+++ b/dc/council/periods/19/laws/19-311.xml
@@ -95,8 +95,6 @@
               <text>Includes such appropriate laboratory and other diagnostic studies prescribed by the Police and Fire Clinic.</text>
             </para>
           </para>
-          <annotation doc="D.C. Law 15-194" type="History" path="§651">Sept. 30, 2004, D.C. Law 15-194, § 651</annotation>
-          
           <annotation type="Effect of Amendments">The 2013 amendment by <cite doc="D.C. Law 19-311">D.C. Law 19-311</cite> added this section.</annotation>
           <!-- <annotation type="Applicability">Section 656 of <cite doc="D.C. Law 15-194">D.C. Law 15-194</cite>, as added by <cite doc="D.C. Law 19-311">D.C. Law 19-311</cite>, § 2, provided that this subchapter shall apply upon the inclusion of its fiscal effect in an approved budget and financial plan, as certified by the Chief Financial Officer to the Budget Director of the Council in a certification published by the Council in the District of Columbia Register.</annotation> -->
           

--- a/dc/council/periods/21/laws/21-160.xml
+++ b/dc/council/periods/21/laws/21-160.xml
@@ -2828,7 +2828,6 @@
                 <num>(c)</num>
                 <text>For any member or EMS employee hired after May 1, 2013, the District may require additional, appropriate laboratory and other diagnostic studies to be included as part of the pre-employment physical examination; provided, that any such requirements shall be applicable to all members or EMS employees.</text>
               </para>
-              <annotation doc="D.C. Law 15-194" type="History" path="655a">Sept. 30, 2004, D.C. Law 15-194, § 655a</annotation>
             </section>
             <section>
               <codify:insert path="VI|D" after="§655a" history-prefix="as added"/>
@@ -2860,7 +2859,6 @@
                 <num>(6)</num>
                 <text>The total number of claims made by EMS employees in which a presumption was created under <code-cite path="§654">section 654</code-cite>.</text>
               </para>
-              <annotation doc="D.C. Law 15-194" type="History" path="655b">Sept. 30, 2004, D.C. Law 15-194, § 655b</annotation>
             </section>
             <section>
               <codify:insert path="VI|D" after="§655b" history-prefix="as added"/>
@@ -2868,7 +2866,6 @@
               <num>655c</num>
               <heading>Rules.</heading>
               <text>The Mayor, pursuant to Title I of the District of Columbia Administrative Procedure Act, approved October 21, 1968 (82 Stat. 1204; D.C. Official Code § 2-501 <em>et seq.</em>), may issue rules to implement the provisions of this subtitle.</text>
-              <annotation doc="D.C. Law 15-194" type="History" path="655c">Sept. 30, 2004, D.C. Law 15-194, § 655c</annotation>
             </section>
           </include>
           <aftertext>.</aftertext>
@@ -7294,7 +7291,6 @@
                 <num>(b)</num>
                 <text>The Agency, foster parents, and group homes shall not be held liable for any civil damages resulting from the application of, or the failure to apply, the reasonable and prudent parent standard, except in cases constituting gross negligence.</text>
               </para>
-              <annotation doc="D.C. Law 2-22" type="History" path="§303f">Sept. 23, 1977, D.C. Law 2-22, title III, § 303f</annotation>
             </section>
           </include>
           <aftertext>.</aftertext>

--- a/dc/council/periods/22/laws/22-21.xml
+++ b/dc/council/periods/22/laws/22-21.xml
@@ -741,8 +741,8 @@
       <codify:applicability doc="D.C. Law 22-21" path="§2|(a)" date="pending" history="false"/>
       <codify:applicability doc="D.C. Law 22-21" path="§2|(b)" date="pending" history="false"/>
       <codify:applicability doc="D.C. Law 22-21" path="§2|(c)" date="notfunded" history="false" action="creation of"/>
-      <codify:applicability doc="D.C. Law 22-21" path="§3|(a)" date="notfunded"/>
-      <codify:applicability doc="D.C. Law 22-21" path="§3|(b)" date="notfunded"/>
+      <codify:applicability doc="D.C. Law 22-21" path="§3|(b)" date="notfunded" history="false"/>
+      <codify:applicability doc="D.C. Law 22-21" path="§3|(a)" date="notfunded" history="false"/>
       <codify:applicability doc="D.C. Law 22-21" path="§4" date="notfunded" history="false"/>
       <codify:applicability doc="D.C. Law 22-21" path="§7" date="notfunded" history="false"/>
       <codify:applicability doc="D.C. Law 22-21" path="§8" date="notfunded" history="false"/>


### PR DESCRIPTION
@bbryant: this is ready for review. Just fixes the history of D.C. Law 1-96 (as fixed in several annotations), and removes a bunch of duplicate history entries. 