### PR TITLE
fix code-cite path typo in Law 22-168 (Freedom of Information Act)

### DIFF
--- a/dc/council/periods/22/laws/22-168.xml
+++ b/dc/council/periods/22/laws/22-168.xml
@@ -1392,7 +1392,7 @@
               </para>
               <para>
                 <num>(d)</num>
-                <text>The Office of Open Government may issue advisory opinions on the implementation of <code-cite doc="D.C. Code" path="2|5|I">the Freedom of Information Act of 1976, effective March 29, 1977 (D.C. Law 1-96; D.C. Official Code § 2-531 <em>et seq</em>.)</code-cite>.</text>
+                <text>The Office of Open Government may issue advisory opinions on the implementation of <code-cite doc="D.C. Code" path="2|5|II">the Freedom of Information Act of 1976, effective March 29, 1977 (D.C. Law 1-96; D.C. Official Code § 2-531 <em>et seq</em>.)</code-cite>.</text>
               </para>
               <annotation doc="D.C. Law 19-124" type="History">Apr. 27, 2012, D.C. Law 19-124, § 205c</annotation>
             </section>


### PR DESCRIPTION
Hi!

The citation for the Freedom of Information Act has a typo in Law 22-168:

    <code-cite doc="D.C. Code" path="2|5|I">

should be

    <code-cite doc="D.C. Code" path="2|5|II">

Title 2, Chapter 5, Subchapter I is Administrative Procedure. Subchapter II is Freedom of Information.

This law created [DC Code § 1–1162.05c](https://code.dccouncil.us/dc/council/code/sections/1-1162.05c.html) where the citation appears as

    (d) The Office of Open Government may issue advisory opinions on the
    implementation of subchapter I of Chapter 5 of Title 2.