### PR TITLE
Update 7-1203.02.xml

### DIFF
--- a/dc/council/code/titles/7/sections/7-1203.02.xml
+++ b/dc/council/code/titles/7/sections/7-1203.02.xml
@@ -13,7 +13,7 @@
   </para>
   <para>
     <num>(3)</num>
-    <text>For the purposes of and in accordance with <cite path="7|2A">Chapter 2A of this title</cite> [<cite path="§7-251" proof="true">§ 7-251</cite> seq.].</text>
+    <text>For the purposes of and in accordance with <cite path="7|2B">Chapter 2B of this title</cite> [<cite path="§7-241" proof="true">§ 7-241</cite> seq.].</text>
   </para>
   <annotations>
     <annotation doc="D.C. Law 2-136" type="History" path="§302">Mar. 3, 1979, D.C. Law 2-136, § 302, 25 DCR 5055</annotation>


### PR DESCRIPTION
Typo referenced 2A instead of 2B as it should, and 7-251 (which doesn't exist) instead of 7-241 as it should.

D.C. Law 18-273 amended §7-1203.2 as follows:

Section 302 (D.C. Official Code § 7-1203.02) is amended to read as follows:

“Sec. 302. Disclosures under law.

“Mental health information may be disclosed by a mental health professional or mental health facility where necessary and, to the extent necessary:

“(1) To meet the requirements of D.C. Official Code § 21-586 (concerning financial responsibility for the care of hospitalized persons);

“(2) To meet the compulsory reporting provisions of District or federal law that seek to promote human health and safety, including section 4612 of the Child Facility Review

Committee Establishment Act of 2001, effective October 3, 2001 (D.C. Law 14-28; D.C.

Official Code § 4-1371.12); or

“(3) For the purposes of and in accordance with Title I of the Data-Sharing and Information Coordination Amendment Act of 2010, passed on 2nd reading on June 29, 2010 (Enrolled version of Bill 18-356).”.

 

Title I of the Data Sharing Coordination Act of 2010 is Chapter 2B not Chapter 2A.