### PR TITLE
Update 7-1203.06.xml

### DIFF
--- a/dc/council/code/titles/7/sections/7-1203.06.xml
+++ b/dc/council/code/titles/7/sections/7-1203.06.xml
@@ -2,7 +2,7 @@
 <section xmlns="https://code.dccouncil.us/schemas/dc-library" xmlns:codified="https://code.dccouncil.us/schemas/codified" xmlns:codify="https://code.dccouncil.us/schemas/codify" xmlns:xi="http://www.w3.org/2001/XInclude" containing-doc="D.C. Code">
   <num>7-1203.06</num>
   <heading>Redisclosure.</heading>
-  <text>Mental health information disclosed pursuant to this subchapter shall not be redisclosed except as specifically authorized by subchapter II, III or IV of this chapter or for the purposes of and in accordance with <cite path="7|2A">Chapter 2A of this title</cite> [<cite path="§7-251" proof="true">§ 7-251</cite> et seq.].</text>
+  <text>Mental health information disclosed pursuant to this subchapter shall not be redisclosed except as specifically authorized by subchapter II, III or IV of this chapter or for the purposes of and in accordance with <cite path="7|2B">Chapter 2B of this title</cite> [<cite path="§7-241" proof="true">§ 7-241</cite> et seq.].</text>
   <annotations>
     <annotation doc="D.C. Law 2-136" type="History" path="§306">Mar. 3, 1979, D.C. Law 2-136, § 306, 25 DCR 5055</annotation>
     <annotation doc="D.C. Law 18-273" type="History">Dec. 4, 2010, D.C. Law 18-273, § 204(c), 57 DCR 7171</annotation>


### PR DESCRIPTION
Hi, there is a typo referencing 2A instead of 2B as it should. Title I of the Data Sharing Coordination Act of 2010 is Chapter 2B not Chapter 2A. Also a typo referencing 7-251 (which does not exists) instead of 7-241 as it should