### PR TITLE
Add new macros for emergency and temporary laws

### DIFF
--- a/.macros/codify_not_funded_anno.xml
+++ b/.macros/codify_not_funded_anno.xml
@@ -6,7 +6,7 @@
   <transform>
     <![CDATA[
       {% set applicability_target = doc.resolve_path(attributes.applicability_path) %}
-      <codify:annotation codify:applicability="effective" type="Applicability" {{ attributes|set_attribute('doc', 'path', 'ref') }}>Applicability of <cite {{ doc|ref }}>{{doc.meta.citations.law }}</cite>: <cite {{ applicability_target|ref }}>{{ applicability_target.citations.short }}</cite> provided that the {{ attributes.action }} this section by <cite {{ parent.nearest_ancestor_with_ref|ref }}>{{ parent.nearest_ancestor_with_ref.citations.short }}</cite> is subject to the inclusion of the law’s fiscal effect in an approved budget and financial plan. Therefore that amendment has not been implemented.</codify:annotation>
+      <codify:annotation applicability="effective" type="Editor's Notes" {{ attributes|set_attribute('doc', 'path', 'ref') }}>Applicability of <cite {{ doc|ref }}>{{doc.meta.citations.law }}</cite>: <cite {{ applicability_target|ref }}>{{ applicability_target.citations.short }}</cite> provided that the {{ attributes.action }} this section by <cite {{ parent.nearest_ancestor_with_ref|ref }}>{{ parent.nearest_ancestor_with_ref.citations.short }}</cite> is subject to the inclusion of the law’s fiscal effect in an approved budget and financial plan. Therefore that amendment has not been given effect.</codify:annotation>
     ]]>
   </transform>
 </macro>

--- a/.macros/emergency.xml
+++ b/.macros/emergency.xml
@@ -5,7 +5,7 @@
   <attribute name="applicability" default=""/>
   <transform>
     <![CDATA[
-      <codify:annotation history="false" type="Emergency Legislation" {{ attributes|set_attribute('doc', 'path') }} codify:applicability="{{ attributes.applicability }}">For temporary (90 days) {{ attributes.action }}, see <cite {{ parent|ref }}>{{ parent.citations.full }}</cite>.</codify:annotation>
+      <codify:annotation history="false" type="Emergency Legislation" {{ attributes|set_attribute('doc', 'path') }} applicability="{{ attributes.applicability }}">For temporary (90 days) {{ attributes.action }}, see <cite {{ parent|ref }}>{{ parent.citations.full }}</cite>.</codify:annotation>
     ]]>
   </transform>
 </macro>

--- a/.macros/emergency_new_sec.xml
+++ b/.macros/emergency_new_sec.xml
@@ -1,0 +1,12 @@
+<macro xmlns="https://code.dccouncil.us/schemas/macro" name="emergency-new-sec" lifecycle="amend">
+  <attribute name="doc" required="false"/>
+  <attribute name="interim-path" required="true"/>
+  <attribute name="path" required="true"/>
+  <attribute name="perm-eff" default=""/>
+  <transform>
+    <![CDATA[
+      <codify:annotation history="false" type="Emergency Legislation" {{ attributes|set_attribute('doc') }} path="{{attributes.interim_path}}" expire="{{ attributes.perm_eff }}">For temporary (90 days) creation of § {{ attributes.path.lstrip('§') }}, see <cite {{ parent|ref }}>{{ parent.citations.full }}</cite>.</codify:annotation>
+      <codify:annotation history="false" type="Emergency Legislation" {{ attributes|set_attribute('doc', 'path') }} applicability="{{ attributes.perm_eff or 'tbd'}}" delay="50">For temporary (90 days) creation of § {{ attributes.path.lstrip('§') }}, see <cite {{ parent|ref }}>{{ parent.citations.full }}</cite>.</codify:annotation>
+    ]]>
+  </transform>
+</macro>

--- a/.macros/temporary_new_sec.xml
+++ b/.macros/temporary_new_sec.xml
@@ -1,0 +1,12 @@
+<macro xmlns="https://code.dccouncil.us/schemas/macro" name="temporary-new-sec" lifecycle="amend">
+  <attribute name="doc" required="false"/>
+  <attribute name="interim-path" required="true"/>
+  <attribute name="path" required="true"/>
+  <attribute name="perm-eff" default=""/>
+  <transform>
+    <![CDATA[
+      <codify:annotation history="false" type="Temporary Legislation" {{ attributes|set_attribute('doc') }} path="{{attributes.interim_path}}" expire="{{ attributes.perm_eff }}">For temporary (225 days) creation of § {{ attributes.path.lstrip('§') }}, see <cite {{ parent|ref }}>{{ parent.citations.full }}</cite>.</codify:annotation>
+      <codify:annotation history="false" type="Temporary Legislation" {{ attributes|set_attribute('doc', 'path') }} applicability="{{ attributes.perm_eff or 'tbd'}}" delay="50">For temporary (225 days) creation of § {{ attributes.path.lstrip('§') }}, see <cite {{ parent|ref }}>{{ parent.citations.full }}</cite>.</codify:annotation>
+    ]]>
+  </transform>
+</macro>

--- a/dc/council/periods/22/acts/22-630.xml
+++ b/dc/council/periods/22/acts/22-630.xml
@@ -306,7 +306,7 @@
             <num>301</num>
             <heading>Authorization of sports wagering.</heading>
             <text>The operation of sports wagering and related activities shall be lawful in the District of Columbia and conducted in accordance with this title, and rules and regulations issued pursuant to this title.</text>
-            <codify:annotation doc="D.C. Code" path="§36-621.01" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.01" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -400,7 +400,7 @@
               <num>(c)</num>
               <text>Sports wagering shall occur only in the specific locations within a designated sports wagering facility approved by the Office and may only be relocated or offered in an additional manner pursuant to regulation.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.02" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.02" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -422,7 +422,7 @@
                 <text>Records, documents, and information in the possession of the Office received pursuant to an intelligence-sharing, reciprocal-use, or restricted-use agreement shall be considered investigative records compiled for law-enforcement purposes under section 204(a)(3) Freedom of Information Act of 1976, effective March 13, 2004 (D.C. Law 15-105; D.C. Official Code § 2-534(a)(3)).</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.03" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.03" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -455,7 +455,7 @@
               <num>(c)</num>
               <text>The Attorney General for the District of Columbia, in the name of the District of Columbia, may bring an action in the Superior Court of the District of Columbia to enjoin an individual, group of individuals, or entity or to seek a civil penalty of up to $50,000 for a violation of this title or regulations issued pursuant to this title.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.04" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.04" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -600,7 +600,7 @@
                 <text>Submits a request for and obtains a waiver of these contracting requirements pursuant to section 2351 of the CBE act; provided, that if a waiver request is submitted, DSLBD approves or denies the request for waiver within 15 days from day the DSLBD removes the posted waiver request pursuant to section 2351(a-1)(2) of the CBE act; provided, further, that if DSLBD neither approves or denies the request, the waiver shall be approved.</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.05" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.05" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -757,7 +757,7 @@
               <num>(d)</num>
               <text>As a condition of licensure, an operator shall be bonded, in such amounts and in such manner as determined by the Office, and agree, in writing, to indemnify and to save harmless the District of Columbia against any and all actions, claims, and demands of whatever kind or nature that the District of Columbia may incur by reason of or in consequence of issuing an operator license to the licensee.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.06" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.06" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -932,7 +932,7 @@
               <num>(f)</num>
               <text>An operator may continue to use supplies acquired from a licensed sports wagering supplier whose supplier license has expired or has otherwise been cancelled, unless the Office prohibits such use.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.07" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.07" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -978,7 +978,7 @@
               <num>(d)</num>
               <text>An individual, group of individuals, or entity that shares in the revenue of a sports wagering business, including an affiliate operating under a revenue share agreement, shall be licensed under this section.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.08" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.08" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -1012,7 +1012,7 @@
               <num>(e)</num>
               <text>A licensed sports wagering supplier shall submit to the Office a list of all sports wagering equipment or services sold, delivered to, or offered to an operator.  All of such equipment shall be tested and approved by an independent testing laboratory approved by the Office.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.09" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.09" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -1034,7 +1034,7 @@
                 <text>A holder of an occupational license issued pursuant to this section shall pay a renewal fee of $100, which may be paid on behalf of the licensed employee by the employer, and submit a renewal application by September 30 of each year.</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.10" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.10" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -1117,7 +1117,7 @@
                 <text>Twenty-four months after the effective date of this title, the Office of the District of Columbia Auditor shall prepare a study evaluating the performance of the sports wagering instituted by this title to determine the level of District revenue generated by mobile and online gaming compared to other similarly situated jurisdictions and submit the completed study to the Mayor and Council.".</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.11" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.11" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -1171,7 +1171,7 @@
                 </para>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.12" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.12" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -1179,7 +1179,7 @@
             <num>313</num>
             <heading>Clean hands requirement.</heading>
             <text>The Office shall require proof of good standing pursuant to § 29-102.08 of an applicant for a license pursuant to this title and may, in addition, require certification that the Citywide Clean Hands Database indicates that the proposed licensee is current with its District taxes.</text>
-            <codify:annotation doc="D.C. Code" path="§36-621.13" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.13" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -1206,7 +1206,7 @@
               <num>(b)</num>
               <text>An individual, group of individuals, or entity that has been fined or whose application has been denied, revoked, or suspended pursuant to this section shall have a right to a hearing before the Office and, in the event of its affirmation of the fine, denial, revocation, or suspension, whichever applies, the right to appeal the decision of the Office to the Superior Court of the District of Columbia.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.14" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.14" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -1241,7 +1241,7 @@
                 <text>Of the remaining balance, 50% shall be used to fund the Birth-to-Three for All DC Amendment Act of 2018, effective October 30, 2018 (D.C. Law 22-179; D.C. Official Code § 4-651.01 <em>et seq.</em>), and 50% shall be deposited into the Neighborhood Safety and Engagement Fund, established by section 103 of the Neighborhood Engagement Achieves Results Amendment Act of 2016, effective June 30, 2016 (D.C. Law 21-125; D.C. Official Code § 7-2413).</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.15" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.15" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -1349,7 +1349,7 @@
                 <text>Each Class A and Cass B licensee shall provide to the Office a report to the Office on its CBE participation.</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.16" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.16" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>
@@ -1357,7 +1357,7 @@
             <num>317</num>
             <heading>Conflict with federal law.</heading>
             <text>Nothing in this title shall be construed to authorize noncompliance with any provision of any federal law or regulation. Notwithstanding any provision in this title, no sports wagering, or gambling in any form, or the operation of gambling devises shall be allowed on federal property, or portion of federal property, where such activity is prohibited by federal law or regulation or is contrary to section 602(a)(3) of the District of Columbia Home Rule Act, approved December 24, 1973 (87 Stat. 813; D.C. Official Code § 1-206.02(a)(3)).</text>
-            <codify:annotation doc="D.C. Code" path="§36-621.17" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.17" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 22-630" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Emergency Amendment Act of 2018 (D.C. Act 22-630, Jan. 30, 2019, 66 DCR 1745)</cite>.
             </codify:annotation>
           </section>

--- a/dc/council/periods/23/acts/23-105.xml
+++ b/dc/council/periods/23/acts/23-105.xml
@@ -145,7 +145,7 @@
       </include>
       <aftertext>.</aftertext>
     </para>
-   <codify:annotation doc="D.C. Code" path="§[47-4671]" type="Applicability" history="false" codify:applicability="2019-09-11">
+   <codify:annotation doc="D.C. Code" path="§[47-4671]" type="Applicability" history="false" applicability="2019-09-11">
      For temporary (90 days) creation of this section, see section 2 of the MLK Gateway Real Property Tax Abatement Emergency Amendment Act of 2019 (D.C. Act 23-105, July 24, 2019, 66 DCR 9750).
    </codify:annotation>
   </section>

--- a/dc/council/periods/23/acts/23-41.xml
+++ b/dc/council/periods/23/acts/23-41.xml
@@ -382,7 +382,7 @@
                 <text>"Respondent" means a person against whom an extreme risk protection order is sought.</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§7-2510.01" type="Emergency Legislation" history="false" codify:applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
+            <codify:annotation doc="D.C. Code" path="§7-2510.01" type="Emergency Legislation" history="false" applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
             </codify:annotation>
           </section>
           <section>
@@ -436,7 +436,7 @@
               <num>(d)</num>
               <text>At the request of the petitioner or respondent, the court may place any record or part of a proceeding related to the issuance, renewal, or termination of an extreme risk protection order under seal while the petition is pending.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§7-2510.02" type="Emergency Legislation" history="false" codify:applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
+            <codify:annotation doc="D.C. Code" path="§7-2510.02" type="Emergency Legislation" history="false" applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
             </codify:annotation>
           </section>
           <section>
@@ -576,7 +576,7 @@
               <num>(i)</num>
               <text>A final extreme risk protection order issued pursuant to this section shall expire one year after the issuance of the order, unless the order is terminated pursuant to section 1008 before its expiration.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§7-2510.03" type="Emergency Legislation" history="false" codify:applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
+            <codify:annotation doc="D.C. Code" path="§7-2510.03" type="Emergency Legislation" history="false" applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
             </codify:annotation>
           </section>
           <section>
@@ -694,7 +694,7 @@
               <num>(i)</num>
               <text>The court shall terminate an ex parte extreme risk protection order in effect against the respondent at the time the court grants or denies the petition for a final extreme risk protection order.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§7-2510.04" type="Emergency Legislation" history="false" codify:applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
+            <codify:annotation doc="D.C. Code" path="§7-2510.04" type="Emergency Legislation" history="false" applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
             </codify:annotation>
           </section>
           <section>
@@ -723,7 +723,7 @@
               <num>(b)</num>
               <text>If the respondent was personally served in court when the extreme risk protection order was issued, the requirements of subsection (a) of this section shall be waived.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§7-2510.05" type="Emergency Legislation" history="false" codify:applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
+            <codify:annotation doc="D.C. Code" path="§7-2510.05" type="Emergency Legislation" history="false" applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
             </codify:annotation>
           </section>
           <section>
@@ -829,7 +829,7 @@
               <num>(h)</num>
               <text>An extreme risk protection order renewed pursuant to this section shall expire one year after the issuance of the order, unless that order is terminated pursuant to section 1008 before its expiration.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§7-2510.06" type="Emergency Legislation" history="false" codify:applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
+            <codify:annotation doc="D.C. Code" path="§7-2510.06" type="Emergency Legislation" history="false" applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
             </codify:annotation>
           </section>
           <section>
@@ -905,7 +905,7 @@
                 <text>The surrender of any firearm or ammunition pursuant to this section shall not constitute a voluntary surrender for the purposes of section 705.</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§7-2510.07" type="Emergency Legislation" history="false" codify:applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
+            <codify:annotation doc="D.C. Code" path="§7-2510.07" type="Emergency Legislation" history="false" applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
             </codify:annotation>
           </section>
           <section>
@@ -982,7 +982,7 @@
                 <text>Within one business day after service, the Metropolitan Police Department shall submit proof of service to the court.</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§7-2510.08" type="Emergency Legislation" history="false" codify:applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
+            <codify:annotation doc="D.C. Code" path="§7-2510.08" type="Emergency Legislation" history="false" applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
             </codify:annotation>
           </section>
           <section>
@@ -1026,7 +1026,7 @@
               <num>(c)</num>
               <text>If the respondent does not request return of a firearm or ammunition under subsection (a) of this section, or sell or transfer a firearm or ammunition under subsection (b) of this section, within 6 months after the date the extreme risk protection order is terminated, or expires and is not renewed, the Metropolitan Police Department shall treat the firearm or ammunition as surrendered and the firearm or ammunition shall be subject to section 705(b).</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§7-2510.09" type="Emergency Legislation" history="false" codify:applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
+            <codify:annotation doc="D.C. Code" path="§7-2510.09" type="Emergency Legislation" history="false" applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
             </codify:annotation>
           </section>
           <section>
@@ -1048,7 +1048,7 @@
               <num>(b)</num>
               <text>The Superior Court of the District of Columbia shall immediately submit information about extreme risk protection orders issued, renewed, or terminated pursuant to this title to the National Instant Criminal Background Check System for the purposes of firearm purchaser background checks.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§7-2510.10" type="Emergency Legislation" history="false" codify:applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
+            <codify:annotation doc="D.C. Code" path="§7-2510.10" type="Emergency Legislation" history="false" applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
             </codify:annotation>
           </section>
           <section>
@@ -1082,14 +1082,14 @@
                 <text>Gun offense, as that term is defined in section 801(3).</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§7-2510.11" type="Emergency Legislation" history="false" codify:applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
+            <codify:annotation doc="D.C. Code" path="§7-2510.11" type="Emergency Legislation" history="false" applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
             </codify:annotation>
           </section>
           <section>
             <num>1012</num>
             <heading>Law enforcement to retain other authority.</heading>
             <text>Nothing in this title shall be construed to affect the ability of a law enforcement officer, as that term is defined in section 901(3), to remove firearms or ammunition from any person pursuant to other lawful authority.</text>
-            <codify:annotation doc="D.C. Code" path="§7-2510.12" type="Emergency Legislation" history="false" codify:applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
+            <codify:annotation doc="D.C. Code" path="§7-2510.12" type="Emergency Legislation" history="false" applicability="2019-06-01"><cite doc="D.C. Act 23-41" path="2|(e)">For temporary (90 days) creation of this section, see § 2(e) of Firearms Safety Omnibus Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-41, Apr. 15, 2019, 66 DCR 5255)</cite>.
             </codify:annotation>
           </section>
         </container>

--- a/dc/council/periods/23/acts/23-43.xml
+++ b/dc/council/periods/23/acts/23-43.xml
@@ -230,7 +230,7 @@
           </include>
           <aftertext>.</aftertext>
         </para>
-        <codify:annotation doc="D.C. Code" path="§36-601.01" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(1)">
+        <codify:annotation doc="D.C. Code" path="§36-601.01" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(1)">
         For temporary (90 days) amendment of this section, see § 2(d)(1) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
         </codify:annotation>
       </para>
@@ -244,28 +244,28 @@
           </para>
         </include>
         <aftertext>.</aftertext>
-        <codify:annotation doc="D.C. Code" path="§36-601.03" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(2)">
+        <codify:annotation doc="D.C. Code" path="§36-601.03" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(2)">
         For temporary (90 days) amendment of this section, see § 2(d)(2) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
         </codify:annotation>
       </para>
       <para>
         <num>(3)</num>
         <text>Section 4 (D.C. Official Code § 3-1305) is amended by striking the phrase "or Monte Carlo night party" wherever it appears and inserting the phrase "Monte Carlo night party, or sports wagering" in its place.</text>
-        <codify:annotation doc="D.C. Code" path="§36-601.05" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(3)">
+        <codify:annotation doc="D.C. Code" path="§36-601.05" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(3)">
         For temporary (90 days) amendment of this section, see § 2(d)(3) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
         </codify:annotation>
       </para>
       <para>
         <num>(4)</num>
         <text>Section 4(a) (D.C. Official Code § 3-1306(a)) is amended by striking the phrase "enterprises; for insuring" and inserting the phrase "enterprises; for auditing the books and records of sports wagering licensees; for insuring" in its place.</text>
-        <codify:annotation doc="D.C. Code" path="§36-601.06" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(4)">
+        <codify:annotation doc="D.C. Code" path="§36-601.06" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(4)">
         For temporary (90 days) amendment of this section, see § 2(d)(4) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
         </codify:annotation>
       </para>
       <para>
         <num>(5)</num>
         <text>Section 4 (D.C. Official Code § 3-1309) is amended by striking the phrase "and Monte Carlo Night parties," and inserting the phrase "Monte Carlo Night parties, and authorized sports wagering," in its place.</text>
-        <codify:annotation doc="D.C. Code" path="§36-601.09" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(5)">
+        <codify:annotation doc="D.C. Code" path="§36-601.09" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(5)">
         For temporary (90 days) amendment of this section, see § 2(d)(5) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
         </codify:annotation>
       </para>
@@ -291,21 +291,21 @@
           <num>(C)</num>
           <text>Subsection (c) is amended by striking the phrase "District of Columbia." and inserting the phrase "District of Columbia or as otherwise directed by this act." in its place.</text>
         </para>
-        <codify:annotation doc="D.C. Code" path="§36-601.12" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(6)">
+        <codify:annotation doc="D.C. Code" path="§36-601.12" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(6)">
         For temporary (90 days) amendment of this section, see § 2(d)(6) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
         </codify:annotation>
       </para>
       <para>
         <num>(7)</num>
         <text>Section 4(a) (D.C. Official Code § 3-1316(a)) is amended by striking the word "Board" both times it appears and inserting the word "Office" in its place.</text>
-        <codify:annotation doc="D.C. Code" path="§36-601.16" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(7)">
+        <codify:annotation doc="D.C. Code" path="§36-601.16" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(7)">
         For temporary (90 days) amendment of this section, see § 2(d)(7) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
         </codify:annotation>
       </para>
       <para>
         <num>(8)</num>
         <text>Section 4 (D.C. Official Code § 3-1319) is amended by striking the phrase "and daily numbers games." and inserting the phrase ", daily numbers games, and sports wagering." in its place.</text>
-        <codify:annotation doc="D.C. Code" path="§36-601.19" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(8)">
+        <codify:annotation doc="D.C. Code" path="§36-601.19" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(d)|(8)">
         For temporary (90 days) amendment of this section, see § 2(d)(8) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
         </codify:annotation>
       </para>
@@ -322,7 +322,7 @@
             <num>301</num>
             <heading>Authorization of sports wagering.</heading>
             <text>The operation of sports wagering and related activities shall be lawful in the District of Columbia and conducted in accordance with this title, and rules and regulations issued pursuant to this title.</text>
-            <codify:annotation doc="D.C. Code" path="§36-621.01" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.01" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -416,7 +416,7 @@
               <num>(c)</num>
               <text>Sports wagering shall occur only in the specific locations within a designated sports wagering facility approved by the Office and may only be relocated or offered in an additional manner pursuant to regulation.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.02" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.02" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -438,7 +438,7 @@
                 <text>Records, documents, and information in the possession of the Office received pursuant to an intelligence-sharing, reciprocal-use, or restricted-use agreement shall be considered investigative records compiled for law-enforcement purposes under section 204(a)(3) of the Freedom of Information Act of 1976, effective March 13, 2004 (D.C. Law 15-105; D.C. Official Code § 2-534(a)(3)).</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.03" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.03" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -471,7 +471,7 @@
               <num>(c)</num>
               <text>The Attorney General for the District of Columbia, in the name of the District of Columbia, may bring an action in the Superior Court of the District of Columbia to enjoin an individual, group of individuals, or entity or to seek a civil penalty of up to $50,000 for a violation of this title or regulations issued pursuant to this title.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.04" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.04" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -616,7 +616,7 @@
                 <text>Obtains a waiver from DSLBD of the contracting or joint venture requirements of the CBE act; provided, that if DSLBD neither approves nor denies the request for waiver within 30 days of the submission of the request, the waiver shall be deemed approved as a matter of law.</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.05" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.05" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -773,7 +773,7 @@
               <num>(d)</num>
               <text>As a condition of licensure, an operator shall be bonded, in such amounts and in such manner as determined by the Office, and agree, in writing, to indemnify and to save harmless the District of Columbia against any and all actions, claims, and demands of whatever kind or nature that the District of Columbia may incur by reason of or in consequence of issuing an operator license to the licensee.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.06" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.06" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -948,7 +948,7 @@
               <num>(f)</num>
               <text>An operator may continue to use supplies acquired from a licensed sports wagering supplier whose supplier license has expired or has otherwise been cancelled, unless the Office prohibits such use.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.07" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.07" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -994,7 +994,7 @@
               <num>(d)</num>
               <text>An individual, group of individuals, or entity that shares in the revenue of a sports wagering business, including an affiliate operating under a revenue share agreement, shall be licensed under this section.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.08" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.08" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -1028,7 +1028,7 @@
               <num>(e)</num>
               <text>A licensed sports wagering supplier shall submit to the Office a list of all sports wagering equipment or services sold, delivered to, or offered to an operator.  All of such equipment shall be tested and approved by an independent testing laboratory approved by the Office.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.09" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.09" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -1050,7 +1050,7 @@
                 <text>A holder of an occupational license issued pursuant to this section shall pay a renewal fee of $100, which may be paid on behalf of the licensed employee by the employer, and submit a renewal application by September 30 of each year.</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.10" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.10" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -1133,7 +1133,7 @@
                 <text>Twenty-four months after the effective date of this title, the Office of the District of Columbia Auditor shall prepare a study evaluating the performance of the sports wagering instituted by this title to determine the level of District revenue generated by mobile and online gaming compared to other similarly situated jurisdictions and submit the completed study to the Mayor and Council.".</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.11" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.11" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -1187,7 +1187,7 @@
                 </para>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.12" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.12" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -1195,7 +1195,7 @@
             <num>313</num>
             <heading>Clean hands requirement.</heading>
             <text>The Office shall require proof of good standing pursuant to § 29-102.08 of an applicant for a license pursuant to this title and may, in addition, require certification that the Citywide Clean Hands Database indicates that the proposed licensee is current with its District taxes.</text>
-            <codify:annotation doc="D.C. Code" path="§36-621.13" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.13" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -1222,7 +1222,7 @@
               <num>(b)</num>
               <text>An individual, group of individuals, or entity that has been fined or whose application has been denied, revoked, or suspended pursuant to this section shall have a right to a hearing before the Office and, in the event of its affirmation of the fine, denial, revocation, or suspension, whichever applies, the right to appeal the decision of the Office to the Superior Court of the District of Columbia.</text>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.14" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.14" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -1257,7 +1257,7 @@
                 <text>Of the remaining balance, 50% shall be used to fund the Birth-to-Three for All DC Amendment Act of 2018, effective October 30, 2018 (D.C. Law 22-179; D.C. Official Code § 4-651.01 <em>et seq.</em>), and 50% shall be deposited into the Neighborhood Safety and Engagement Fund, established by section 103 of the Neighborhood Engagement Achieves Results Amendment Act of 2016, effective June 30, 2016 (D.C. Law 21-125; D.C. Official Code § 7-2413).</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.15" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.15" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -1365,7 +1365,7 @@
                 <text>Each Class A and Class B licensee shall provide to the Office a report to the Office on its CBE participation.</text>
               </para>
             </para>
-            <codify:annotation doc="D.C. Code" path="§36-621.16" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.16" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>
@@ -1373,7 +1373,7 @@
             <num>317</num>
             <heading>Conflict with federal law.</heading>
             <text>Nothing in this title shall be construed to authorize noncompliance with any provision of any federal law or regulation.  Notwithstanding any provision in this title, no sports wagering, or gambling in any form, or the operation of gambling devices shall be allowed on federal property, or portion of federal property, where such activity is prohibited by federal law or regulation or is contrary to section 602(a)(3) of the District of Columbia Home Rule Act, approved December 24, 1973 (87 Stat. 813; D.C. Official Code § 1-206.02(a)(3)).</text>
-            <codify:annotation doc="D.C. Code" path="§36-621.17" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
+            <codify:annotation doc="D.C. Code" path="§36-621.17" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-43" path="2|(e)">
             For temporary (90 days) creation of this section, see § 2(e) of the Sports Wagering Lottery Congressional Review Emergency Amendment Act of 2018 (D.C. Act 23-43, Apr. 15, 2019, 66 DCR 5273)</cite>.
             </codify:annotation>
           </section>

--- a/dc/council/periods/23/acts/23-47.xml
+++ b/dc/council/periods/23/acts/23-47.xml
@@ -32,7 +32,7 @@
         </para>
       </include>
       <aftertext>.</aftertext>
-      <codify:annotation doc="D.C. Code" path="§36-621.05" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-47" path="2|(a)">
+      <codify:annotation doc="D.C. Code" path="§36-621.05" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-47" path="2|(a)">
             For temporary (90 days) amendment of this section, see §§ 2(a) and 3(a) of the Sports Wagering Lottery Clarification Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-47, Apr. 15, 2019, 66 DCR 5301)</cite>.
       </codify:annotation>
     </para>
@@ -47,7 +47,7 @@
         <num>(2)</num>
         <text>Subsection (c)(4)(A) is amended by striking the figure "$50,000" and inserting the figure "$100,000" in its place.</text>
       </para>
-      <codify:annotation doc="D.C. Code" path="§36-621.06" type="Emergency Legislation" history="false" codify:applicability="2019-05-03"><cite doc="D.C. Act 23-47" path="2|(b)">
+      <codify:annotation doc="D.C. Code" path="§36-621.06" type="Emergency Legislation" history="false" applicability="2019-05-03"><cite doc="D.C. Act 23-47" path="2|(b)">
             For temporary (90 days) amendment of this section, see §§ 2(b) and 3(b) of the Sports Wagering Lottery Clarification Congressional Review Emergency Amendment Act of 2019 (D.C. Act 23-47, Apr. 15, 2019, 66 DCR 5301)</cite>.
       </codify:annotation>
     </para>

--- a/dc/council/periods/23/acts/23-68.xml
+++ b/dc/council/periods/23/acts/23-68.xml
@@ -53,7 +53,7 @@
         </section>
       </include>
       <aftertext>.</aftertext>
-      <codify:annotation doc="D.C. Code" path="§47-1099.04" type="Emergency Legislation" history="false" codify:applicability="2019-09-11"><cite doc="D.C. Act 23-68" path="2|(b)">
+      <codify:annotation doc="D.C. Code" path="§47-1099.04" type="Emergency Legislation" history="false" applicability="2019-09-11"><cite doc="D.C. Act 23-68" path="2|(b)">
             For temporary (90 days) creation of § [47-1099.05], see § 2(b) of the Children's Hospital Research and Innovation Campus Phase 1 Emergency Amendment Act of 2019 (D.C. Act 23-68, June 20, 2019, 66 DCR 7610)</cite>.
       </codify:annotation>
     </para>

--- a/dc/council/periods/23/acts/23-84.xml
+++ b/dc/council/periods/23/acts/23-84.xml
@@ -45,7 +45,7 @@
           <num>(4)</num>
           <text>"Temporary Assistance for Needy Families" or "TANF" means the Temporary Assistance for Needy Families program established by section 201(5) of the District of Columbia Public Assistance Act of 1982, effective April 6, 1982 (D.C. Law 4-101; D.C. Official Code § 4-202.01(5)).</text>
         </para>
-        <codify:annotation path="§4-251.21" type="Emergency Legislation" history="false" codify:applicability="2019-11-26">
+        <codify:annotation path="§4-251.21" type="Emergency Legislation" history="false" applicability="2019-11-26">
           For temporary (90 days) creation of this section, see § 101 of Close Relative Caregiver Subsidy Pilot Program Establishment Emergency Amendment Act of 2019 (D.C. Act 23-84, July 16, 2019, 66 DCR 8274).
         </codify:annotation>
       </para>
@@ -61,7 +61,7 @@
         <num>(b)</num>
         <text>The Pilot Program shall continue through September 30, 2023.</text>
       </para>
-      <codify:annotation path="§4-251.22" type="Emergency Legislation" history="false" codify:applicability="2019-11-26">
+      <codify:annotation path="§4-251.22" type="Emergency Legislation" history="false" applicability="2019-11-26">
           For temporary (90 days) creation of this section, see § 102 of Close Relative Caregiver Subsidy Pilot Program Establishment Emergency Amendment Act of 2019 (D.C. Act 23-84, July 16, 2019, 66 DCR 8274).
         </codify:annotation>
     </section>
@@ -188,7 +188,7 @@
         <num>(g)</num>
         <text>Any statement made pursuant to this section made with knowledge that the information set forth therein is false shall be subject to prosecution as a false statement under section 404(a) of the District of Columbia Theft and White Collar Crimes Act of 1982, effective December 1, 1982 (D.C. Law 4-164; D.C. Official Code § 22-2405(a)).</text>
       </para>
-      <codify:annotation path="§4-251.23" type="Emergency Legislation" history="false" codify:applicability="2019-11-26">
+      <codify:annotation path="§4-251.23" type="Emergency Legislation" history="false" applicability="2019-11-26">
           For temporary (90 days) creation of this section, see § 103 of Close Relative Caregiver Subsidy Pilot Program Establishment Emergency Amendment Act of 2019 (D.C. Act 23-84, July 16, 2019, 66 DCR 8274).
         </codify:annotation>
     </section>
@@ -211,7 +211,7 @@
         <num>(d)</num>
         <text>The Mayor may give priority to the application of a close relative for a subsidy if the Agency determines that the child is at risk of removal from the parent, guardian, or custodian pursuant to section 107 of the Prevention of Child Abuse and Neglect Act of 1977, effective September 23, 1977 (D.C. Law 2-22; D.C. Official Code § 4-1301.07).</text>
       </para>
-      <codify:annotation path="§4-251.24" type="Emergency Legislation" history="false" codify:applicability="2019-11-26">
+      <codify:annotation path="§4-251.24" type="Emergency Legislation" history="false" applicability="2019-11-26">
           For temporary (90 days) creation of this section, see § 104 of Close Relative Caregiver Subsidy Pilot Program Establishment Emergency Amendment Act of 2019 (D.C. Act 23-84, July 16, 2019, 66 DCR 8274).
         </codify:annotation>
     </section>
@@ -262,7 +262,7 @@
           <text>Any legislative, policy, or administrative recommendations of the Family Court of the Superior Court of the District of Columbia or of agencies designated by the Mayor to execute the provisions of this act that are intended to enhance the effectiveness of the Pilot Program.</text>
         </para>
       </para>
-      <codify:annotation path="§4-251.25" type="Emergency Legislation" history="false" codify:applicability="2019-11-26">
+      <codify:annotation path="§4-251.25" type="Emergency Legislation" history="false" applicability="2019-11-26">
           For temporary (90 days) creation of this section, see § 105 of Close Relative Caregiver Subsidy Pilot Program Establishment Emergency Amendment Act of 2019 (D.C. Act 23-84, July 16, 2019, 66 DCR 8274).
         </codify:annotation>
     </section>
@@ -270,7 +270,7 @@
       <num>106</num>
       <heading>Rules.</heading>
       <text>The Mayor, pursuant to pursuant to Title I of the District of Columbia Administrative Procedure Act, approved October 21, 1968 (82 Stat. 1204; D.C. Official Code § 2-501 <em>et seq</em>.), may issue rules to implement the provisions of this act.</text>
-      <codify:annotation path="§4-251.26" type="Emergency Legislation" history="false" codify:applicability="2019-11-26">
+      <codify:annotation path="§4-251.26" type="Emergency Legislation" history="false" applicability="2019-11-26">
           For temporary (90 days) creation of this section, see § 106 of Close Relative Caregiver Subsidy Pilot Program Establishment Emergency Amendment Act of 2019 (D.C. Act 23-84, July 16, 2019, 66 DCR 8274).
         </codify:annotation>
     </section>
@@ -285,7 +285,7 @@
         <num>(b)</num>
         <text>Nothing in this act shall be construed to create a new cause of action or to limit the rights or remedies available to parents in custody or guardianship actions.</text>
       </para>
-      <codify:annotation path="§4-251.27" type="Emergency Legislation" history="false" codify:applicability="2019-11-26">
+      <codify:annotation path="§4-251.27" type="Emergency Legislation" history="false" applicability="2019-11-26">
           For temporary (90 days) creation of this section, see § 107 of Close Relative Caregiver Subsidy Pilot Program Establishment Emergency Amendment Act of 2019 (D.C. Act 23-84, July 16, 2019, 66 DCR 8274).
         </codify:annotation>
     </section>

--- a/dc/council/periods/23/acts/23-91.xml
+++ b/dc/council/periods/23/acts/23-91.xml
@@ -73,7 +73,7 @@
             </section>
           </include>
           <aftertext>.</aftertext>
-           <codify:annotation codify:doc="D.C. Code" path="§1-307.91a" type="Emergency Legislation" history="false" codify:applicability="2019-09-11">
+           <codify:annotation codify:doc="D.C. Code" path="§1-307.91a" type="Emergency Legislation" history="false" applicability="2019-09-11">
           For temporary (90 days) creation of this section, see <cite doc="D.C. Act" path="§1002">§ 1002 of the Fiscal Year 2020 Budget Support Emergency Act of 2019(D.C. Act 23-91, July 22, 2019</cite>, 66 DCR 8497).
         </codify:annotation>
         </para>
@@ -148,7 +148,7 @@
           <num>(b)</num>
           <text>The Council shall develop guidelines for the Council Employee Student Loan Repayment Assistance Program to include eligible loans, employee obligations, and calculation of benefits.</text>
         </para>
-        <codify:annotation codify:doc="D.C. Code" path="§1-545.01" type="Emergency Legislation" history="false" codify:applicability="2019-09-11">
+        <codify:annotation codify:doc="D.C. Code" path="§1-545.01" type="Emergency Legislation" history="false" applicability="2019-09-11">
           For temporary (90 days) creation of this section, see <cite doc="D.C. Act" path="§1032">§ 1032 of the Fiscal Year 2020 Budget Support Emergency Act of 2019(D.C. Act 23-91, July 22, 2019</cite>, 66 DCR 8497).
         </codify:annotation>
       </section>

--- a/dc/council/periods/23/laws/23-25.xml
+++ b/dc/council/periods/23/laws/23-25.xml
@@ -49,7 +49,7 @@
           <text>"Temporary Assistance for Needy Families" or "TANF" means the Temporary Assistance for Needy Families program established by section 201(5) of the District of Columbia Public Assistance Act of 1982, effective April 6, 1982 (D.C. Law 4-101; D.C. Official Code § 4-202.01(5)).</text>
         </para>
       </para>
-      <codify:annotation path="§4-251.21" type="Temporary Legislation" history="false" codify:applicability="2019-11-27">
+      <codify:annotation path="§4-251.21" type="Temporary Legislation" history="false" applicability="2019-11-27">
           For temporary (225 days) creation of this section, see § 101 of Close Relative Caregiver Subsidy Pilot Program Establishment Temporary Amendment Act of 2019 (D.C. Law 23-25, Oct. 24, 2019, 66 DCR 12081).
         </codify:annotation>
     </section>
@@ -64,7 +64,7 @@
         <num>(b)</num>
         <text>The Pilot Program shall continue through September 30, 2023.</text>
       </para>
-      <codify:annotation path="§4-251.22" type="Temporary Legislation" history="false" codify:applicability="2019-11-27">
+      <codify:annotation path="§4-251.22" type="Temporary Legislation" history="false" applicability="2019-11-27">
           For temporary (225 days) creation of this section, see § 102 of Close Relative Caregiver Subsidy Pilot Program Establishment Temporary Amendment Act of 2019 (D.C. Law 23-25, Oct. 24, 2019, 66 DCR 12081).
         </codify:annotation>
     </section>
@@ -189,7 +189,7 @@
         <num>(g)</num>
         <text>Any statement made pursuant to this section made with knowledge that the information set forth therein is false shall be subject to prosecution as a false statement under section 404(a) of the District of Columbia Theft and White Collar Crimes Act of 1982, effective December 1, 1982 (D.C. Law 4-164; D.C. Official Code § 22-2405(a)).</text>
       </para>
-      <codify:annotation path="§4-251.23" type="Temporary Legislation" history="false" codify:applicability="2019-11-27">
+      <codify:annotation path="§4-251.23" type="Temporary Legislation" history="false" applicability="2019-11-27">
           For temporary (225 days) creation of this section, see § 103 of Close Relative Caregiver Subsidy Pilot Program Establishment Temporary Amendment Act of 2019 (D.C. Law 23-25, Oct. 24, 2019, 66 DCR 12081).
         </codify:annotation>
     </section>
@@ -212,7 +212,7 @@
         <num>(d)</num>
         <text>The Mayor may give priority to the application of a close relative for a subsidy if the Agency determines that the child is at risk of removal from the parent, guardian, or custodian pursuant to section 107 of the Prevention of Child Abuse and Neglect Act of 1977, effective September 23, 1977 (D.C. Law 2-22; D.C. Official Code § 4-1301.07).</text>
       </para>
-      <codify:annotation path="§4-251.24" type="Temporary Legislation" history="false" codify:applicability="2019-11-27">
+      <codify:annotation path="§4-251.24" type="Temporary Legislation" history="false" applicability="2019-11-27">
           For temporary (225 days) creation of this section, see § 104 of Close Relative Caregiver Subsidy Pilot Program Establishment Temporary Amendment Act of 2019 (D.C. Law 23-25, Oct. 24, 2019, 66 DCR 12081).
         </codify:annotation>
     </section>
@@ -263,7 +263,7 @@
           <text>Any legislative, policy, or administrative recommendations of the Family Court of the Superior Court of the District of Columbia or of agencies designated by the Mayor to execute the provisions of this act that are intended to enhance the effectiveness of the Pilot Program.</text>
         </para>
       </para>
-      <codify:annotation path="§4-251.25" type="Temporary Legislation" history="false" codify:applicability="2019-11-27">
+      <codify:annotation path="§4-251.25" type="Temporary Legislation" history="false" applicability="2019-11-27">
           For temporary (225 days) creation of this section, see § 105 of Close Relative Caregiver Subsidy Pilot Program Establishment Temporary Amendment Act of 2019 (D.C. Law 23-25, Oct. 24, 2019, 66 DCR 12081).
         </codify:annotation>
     </section>
@@ -271,7 +271,7 @@
       <num>106</num>
       <heading>Rules.</heading>
       <text>The Mayor, pursuant to pursuant to Title I of the District of Columbia Administrative Procedure Act, approved October 21, 1968 (82 Stat. 1204; D.C. Official Code § 2-501 <em>et seq</em>.), may issue rules to implement the provisions of this act.</text>
-      <codify:annotation path="§4-251.26" type="Temporary Legislation" history="false" codify:applicability="2019-11-27">
+      <codify:annotation path="§4-251.26" type="Temporary Legislation" history="false" applicability="2019-11-27">
           For temporary (225 days) creation of this section, see § 106 of Close Relative Caregiver Subsidy Pilot Program Establishment Temporary Amendment Act of 2019 (D.C. Law 23-25, Oct. 24, 2019, 66 DCR 12081).
         </codify:annotation>
     </section>
@@ -286,7 +286,7 @@
         <num>(b)</num>
         <text>Nothing in this act shall be construed to create a new cause of action or to limit the rights or remedies available to parents in custody or guardianship actions.</text>
       </para>
-      <codify:annotation path="§4-251.27" type="Temporary Legislation" history="false" codify:applicability="2019-11-27">
+      <codify:annotation path="§4-251.27" type="Temporary Legislation" history="false" applicability="2019-11-27">
           For temporary (225 days) creation of this section, see § 107 of Close Relative Caregiver Subsidy Pilot Program Establishment Temporary Amendment Act of 2019 (D.C. Law 23-25, Oct. 24, 2019, 66 DCR 12081).
         </codify:annotation>
     </section>

--- a/schemas/codify.xsd
+++ b/schemas/codify.xsd
@@ -73,6 +73,19 @@
       </xs:attribute>
     </xs:complexType>
   </xs:element>
+  <xs:element name="emergency-new-sec">
+    <!-- @summary: The ``<codify:emergency-new-sec>`` marcro is used to generate an annotation relating to the codification of an emergency law.-->
+    <xs:complexType>
+      <xs:attributeGroup ref="p:targetAttributes"/>
+      <xs:attributeGroup ref="sharedAttributes"/>
+      <xs:attribute name="interim-path" type="xs:string" use="optional">
+        <!-- @summary: Specifies the path to the existing preceding code section. -->
+      </xs:attribute>
+      <xs:attribute name="perm-eff" type="xs:string" use="optional">
+        <!-- @summary: Specifies the date the law becomes permanently effective. -->
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="find-replace" type="findReplaceType">
     <!-- @summary: The ``<codify:find-replace>`` instruction finds text at the target node and replaces the text at the target with new text. -->
     <!-- @docs: misc/examples_header.rst -->
@@ -251,6 +264,19 @@
       </xs:attribute>
       <xs:attribute name="emergency" type="xs:string" use="optional">
         <!-- @summary: No longer used. -->
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="temporary-new-sec">
+    <!-- @summary: The ``<codify:temporary-new-sec>`` marcro is used to generate an annotation relating to the codification of a temporary law.-->
+    <xs:complexType>
+      <xs:attributeGroup ref="p:targetAttributes"/>
+      <xs:attributeGroup ref="sharedAttributes"/>
+      <xs:attribute name="interim-path" type="xs:string" use="optional">
+        <!-- @summary: Specifies the path to the existing preceding code section. -->
+      </xs:attribute>
+      <xs:attribute name="perm-eff" type="xs:string" use="optional">
+        <!-- @summary: Specifies the date the law becomes permanently effective. -->
       </xs:attribute>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
This PR adds two new macros for code sections created by emergency and temporary laws, `emergency-new-sec` and `temporary-new-sec`. Both the `path` (path to the temporary code section created by law) and the `interim-path` (path to the existing preceding code section) are needed. The `perm-eff` (date the law became permanently effective) may also be given if known. These macros handle moving the emergency and temporary law annotations automatically when the section is permanently created. These are now available as auto-completed code snippets. 

This PR also updates the `emergency` and `codify_not_funded_anno` macros so that `codify:applicability` can now be referenced just by `applicability`. This PR also changes all current instances of `codify:applicability` in laws and acts to just `applicability`.