### PR TITLE
v2019.2.8 Updates and Historical Consistency Updates

### DIFF
--- a/dc/council/periods/22/laws/22-165.xml
+++ b/dc/council/periods/22/laws/22-165.xml
@@ -513,9 +513,10 @@
               <para>
                 <num>(1)</num>
                 <text>If a licensee possesses or has submitted a completed application for a wine pub permit before February 7, 2018, the establishment may sell wine to patrons in sealed bottles or other closed containers for off-premises consumption if the licensee:</text>
-              <para>
-                <num>(A)</num>
-                <text>Maintains an Alcohol and Tobacco Tax and Trade Bureau permit on the licensed premises and provides it to any ABRA Investigator upon request during business hours;</text>
+                <para>
+                  <num>(A)</num>
+                  <text>Maintains an Alcohol and Tobacco Tax and Trade Bureau permit on the licensed premises and provides it to any ABRA Investigator upon request during business hours;</text>
+                </para>
                 <para>
                   <num>(B)</num>
                   <text>Possesses operational wine manufacturing equipment on the licensed premises; and</text>
@@ -523,7 +524,6 @@
                 <para>
                   <num>(C)</num>
                   <text>Produces or makes reasonable efforts, as determined by the Board, to produce at least one type of wine on the licensed premises per calendar year.</text>
-              </para>
                 </para>
               </para>
               <para>

--- a/dc/council/periods/22/laws/22-200.xml
+++ b/dc/council/periods/22/laws/22-200.xml
@@ -351,7 +351,7 @@
             </para>
             <para>
               <num>(2)</num>
-              <text>All rules, orders, obligations, determinations, grants, contracts, licenses, and agreements of the Department of Housing and Community Development relating to functions transferred to the Rental Housing Commission pursuant to the <cite doc="D.C. Law 22-220">Rental Housing Commission Independence Clarification Amendment Act of 2018</cite> <span codify:value="[D.C. Law 22-220, February 22, 2019]">, passed on 2nd reading on October 2, 2018 (Enrolled version of Bill 22-0640)</span>, shall remain in effect according to their terms until lawfully amended, repealed, or modified.</text>
+              <text>All rules, orders, obligations, determinations, grants, contracts, licenses, and agreements of the Department of Housing and Community Development relating to functions transferred to the Rental Housing Commission pursuant to the <cite doc="D.C. Law 22-200">Rental Housing Commission Independence Clarification Amendment Act of 2018</cite> <span codify:value="[D.C. Law 22-200, February 22, 2019]">, passed on 2nd reading on October 2, 2018 (Enrolled version of Bill 22-0640)</span>, shall remain in effect according to their terms until lawfully amended, repealed, or modified.</text>
             </para>
           </para>
           <para>
@@ -473,14 +473,10 @@
     <para>
       <num>(a)</num>
       <text>Sections 2(b)(1), 2(d)(2), amendatory section 202b(c)-(d) contained within section 2(e), and section 3(a) shall apply upon the date of inclusion of their fiscal effects in an approved budget and financial plan.</text>
-      <codify:applicability doc="D.C. Law 22-220" path="§2|(b)|(1)" date="notfunded" history="false"/>
-      <codify:applicability doc="D.C. Law 22-220" path="§2|(d)|(2)" date="notfunded" history="false"/>
-      <codify:repeal doc="D.C. Code" path="§42-3502.02b|(c)" display-template="" history="false"/>
-      <codify:find-replace doc="D.C. Code" path="§42-3502.02b|(c)" display-template="" count="1" history="false">
-        <find>Repeal</find>
-        <replace>Not Funded</replace>
-      </codify:find-replace>
-      <codify:applicability doc="D.C. Law 22-220" path="§3|(a)" date="notfunded" history="false"/>
+      <codify:applicability doc="D.C. Law 22-200" path="§2|(b)|(1)" date="notfunded" history="false"/>
+      <codify:applicability doc="D.C. Law 22-200" path="§2|(d)|(2)" date="notfunded" history="false"/>
+      <codify:applicability doc="D.C. Law 22-200" path="§2|(e)|includes|202b|(c)" date="notfunded" history="false"/>
+      <codify:applicability doc="D.C. Law 22-200" path="§3|(a)" date="notfunded" history="false"/>
     </para>
     <para>
       <num>(b)</num>

--- a/dc/council/periods/23/acts/23-104.xml
+++ b/dc/council/periods/23/acts/23-104.xml
@@ -74,10 +74,7 @@
       </include>
       <aftertext>.</aftertext>
     </para>
-    <codify:find-replace doc="D.C. Code" path="§2-553" count="1" history="false" display-template="DCMR">
-      <find>Documents</find>
-      <replace>Documents</replace>
-    </codify:find-replace>
+    <codify:marginalia display="DCMR"/>
   </section>
   <section>
     <num>4</num>

--- a/dc/council/periods/23/acts/23-286.xml
+++ b/dc/council/periods/23/acts/23-286.xml
@@ -426,10 +426,7 @@
           <text>Section 2299.1 (5-A DCMR § 2299.1) is amended by striking the phrase "one hundred and twenty (120) hours of classroom instruction over the course of an academic year" and inserting the phrase "one hundred and twenty (120) hours of classroom instruction over the course of an academic year; except, that following the Superintendent's approval to grant an exception to the one hundred eighty (180) day instructional day requirement pursuant to 5A DCMR § 2100.3 for school year 2019-20, a Carnegie Unit may consist of fewer than one hundred and twenty (120) hours of classroom instruction over the course of the 2019-2020 academic year for any course in which a student in grades 9-12 is enrolled" in its place.</text>
         </para>
       </container>
-      <codify:find-replace doc="D.C. Code" path="§2-553" count="1" history="false" display-template="DCMR">
-        <find>Documents</find>
-        <replace>Documents</replace>
-      </codify:find-replace>
+      <codify:marginalia display="DCMR"/>
     </section>
   </container>
   <container codify:doc="D.C. Code">
@@ -943,10 +940,7 @@
           <para>
             <num>(A)</num>
             <text>The lead-in language of subparagraph (8) is amended by striking the phrase "customer, or failing to passing" and inserting the phrase "customer, failing to provide to the customer any receipts for amounts advanced, paid, or owed to third parties on behalf of the customer, or failing to pass" in its place.</text>
-            <codify:find-replace doc="D.C. Code" path="§2-553" count="1" history="false" display-template="DCMR">
-              <find>Documents</find>
-              <replace>Documents</replace>
-            </codify:find-replace>
+            <codify:marginalia display="DCMR"/>
           </para>
           <para>
             <num>(B)</num>
@@ -990,10 +984,7 @@
             </subsection>
           </include>
           <aftertext>.</aftertext>
-          <codify:find-replace doc="D.C. Code" path="§2-553" count="1" history="false" display-template="DCMR">
-            <find>Documents</find>
-            <replace>Documents</replace>
-          </codify:find-replace>
+          <codify:marginalia display="DCMR"/>
         </para>
       </para>
     </section>
@@ -2354,10 +2345,7 @@
       <num>506</num>
       <heading>Absentee ballot request signature waiver.</heading>
       <text>Section 720.7(h) of Title 3 of the District of Columbia Municipal Regulations (3 DCMR § 720.7(h)) is amended by striking the phrase "Voter's signature" and inserting the phrase "Except for a request for an absentee ballot for the June 2, 2020, Primary Election or the June 16, 2020, Ward 2 Special Election, voter's signature" in its place.</text>
-      <codify:find-replace doc="D.C. Code" path="§2-553" count="1" history="false" display-template="DCMR">
-        <find>Documents</find>
-        <replace>Documents</replace>
-      </codify:find-replace>
+      <codify:marginalia display="DCMR"/>
     </section>
     <section>
       <num>507</num>

--- a/dc/council/periods/23/acts/23-91.xml
+++ b/dc/council/periods/23/acts/23-91.xml
@@ -6138,10 +6138,7 @@
           </subsection>
         </include>
         <aftertext>.</aftertext>
-        <codify:find-replace doc="D.C. Code" path="§2-553" count="1" history="false" display-template="DCMR">
-          <find>Documents</find>
-          <replace>Documents</replace>
-        </codify:find-replace>
+        <codify:marginalia display="DCMR"/>
       </section>
     </container>
     <container>
@@ -6263,10 +6260,7 @@
       <section>
         <num>6102</num>
         <text>Section 2414.5 of Title 18 of the District of Columbia Municipal Regulations is amended by striking the phrase "Chief of Police" both times it appears and inserting the phrase "Director of the District Department of Transportation" in its place.</text>
-        <codify:find-replace doc="D.C. Code" path="§2-553" count="1" history="false" display-template="DCMR">
-          <find>Documents</find>
-          <replace>Documents</replace>
-        </codify:find-replace>
+        <codify:marginalia display="DCMR"/>
       </section>
       <section>
         <!-- NA -->

--- a/dc/council/periods/23/laws/23-16.xml
+++ b/dc/council/periods/23/laws/23-16.xml
@@ -7178,10 +7178,7 @@
           </subsection>
         </include>
         <aftertext>.</aftertext>
-        <codify:find-replace doc="D.C. Code" path="§2-553" count="1" history="false" display-template="DCMR">
-          <find>Documents</find>
-          <replace>Documents</replace>
-        </codify:find-replace>
+        <codify:marginalia display="DCMR"/>
       </section>
     </container>
     <container>
@@ -7315,10 +7312,7 @@
         <!-- DCMR -->
         <num>6102</num>
         <text>Section 2414.5 of Title 18 of the District of Columbia Municipal Regulations is amended by striking the phrase "Chief of Police" both times it appears and inserting the phrase "Director of the District Department of Transportation" in its place.</text>
-        <codify:find-replace doc="D.C. Code" path="§2-553" count="1" history="false" display-template="DCMR">
-          <find>Documents</find>
-          <replace>Documents</replace>
-        </codify:find-replace>
+        <codify:marginalia display="DCMR"/>
       </section>
       <section>
         <num>6103</num>

--- a/dc/council/periods/23/laws/23-16.xml
+++ b/dc/council/periods/23/laws/23-16.xml
@@ -8988,12 +8988,19 @@
       <section>
         <num>7146</num>
         <text>Section 6(a) of the Senior Dental Services Program Act of 2018, effective June 5, 2018 (D.C. Law 22-108; D.C. Official Code § 7-533.05(a)), is amended by striking the phrase "This act" and inserting the phrase "Starting in Fiscal Year 2021, this act" in its place.</text>
-        <codify:find-replace doc="D.C. Code" path="§7-533.05|(a)" count="1">
-          <find>
-            <code-cite doc="D.C. Code" path="7|5|II-A">This act</code-cite>
-          </find>
-          <replace>Starting in Fiscal Year 2021, <code-cite doc="D.C. Code" path="7|5|II-A">this act</code-cite></replace>
-        </codify:find-replace>
+        <codify:replace doc="D.C. Code" path="§7-533.05|(a)" count="1">
+          <para>
+              <num>(a)</num>
+              <text>Starting in Fiscal Year 2021, <code-cite doc="D.C. Code" path="7|5|II-A">This act</code-cite> shall apply upon the date of inclusion of its fiscal effect in an approved budget and financial plan.</text>
+          </para>
+        </codify:replace>
+        <codify:replace doc="D.C. Code" path="§7-533.05|(a)" count="1" applicability="2020-10-01">
+          <para>
+              <num>(a)</num>
+              <text>Starting in Fiscal Year 2021, <code-cite doc="D.C. Code" path="7|5|II-A">This act</code-cite> shall apply upon the date of inclusion of its fiscal effect in an approved budget and financial plan.</text>
+              <codify:applicability  doc="D.C. Law 22-108" date="notfunded" history="false"/>
+          </para>
+        </codify:replace>
         <codify:annotation doc="D.C. Code" path="§7-533.01" type="Applicability" history="false">
         Applicability of <cite doc="D.C. Law 22-108">D.C. Law 22-108</cite>: <cite doc="D.C. Law 23-16" path="§7146">§ 7146 of D.C. Law 23-16</cite> provided that starting in Fiscal Year 2021 this section shall be subject to appropriations. Therefore the creation of this section by <cite doc="D.C. Law 22-108">D.C. Law 22-108</cite> has been implemented.
         </codify:annotation>

--- a/dc/council/periods/23/laws/23-51.xml
+++ b/dc/council/periods/23/laws/23-51.xml
@@ -730,10 +730,7 @@
       </subsection>
     </include>
     <aftertext>.</aftertext>
-    <codify:find-replace doc="D.C. Code" path="§2-553" count="1" history="false" display-template="DCMR">
-      <find>Documents</find>
-      <replace>Documents</replace>
-    </codify:find-replace>
+    <codify:marginalia display="DCMR"/>
   </section>
   <section>
     <num>5</num>

--- a/schemas/codify.xsd
+++ b/schemas/codify.xsd
@@ -141,6 +141,11 @@
   <xs:element name="insert-code-container" type="anyType">
     <!-- @summary: This instruction has been deprecated and is no longer used.-->
   </xs:element>
+  <xs:element name="marginalia">
+    <xs:complexType>
+      <xs:attributeGroup ref="sharedAttributes"/>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="not-funded-anno">
     <!-- @summary: The ``<codify:not-funded-anno>`` macro is used to generate an annotation for the target element indicating that the target element is not funded.-->
     <xs:complexType>

--- a/schemas/dc-library.xsd
+++ b/schemas/dc-library.xsd
@@ -176,6 +176,7 @@
         </xs:choice>
       </xs:sequence>
       <xs:attribute name="lvl" type="xs:string"/>
+      <xs:attribute name="id" type="xs:string"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="introduced">


### PR DESCRIPTION
Includes schema updates for v2019.2.8:

Adds `<codify:marginalia/>` instruction
Adds `id` attribute to `<include>` elements for needed for unique include paths

Edits for historical consistency:

Law 22-200
Law 23-16

XML edits:

Law 22-165